### PR TITLE
Clarify applicability of special value of 60 in seconds component (#1…

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -17330,6 +17330,11 @@ in the preceding syntax definition.</p>
 minutes, seconds, and frames less than 10. Minutes are constrained to
 [0&hellip;59], while seconds (including any fractional part) are constrained to the closed
 interval [0,60], where the value 60 applies only to leap seconds.</p>
+<note role="clarification">
+<p>The special seconds value 60 is applicable only when leap seconds are counted; namely, when
+<loc href="#parameter-attribute-timeBase"><att>ttp:timeBase</att></loc> is <code>clock</code>
+and <loc href="#parameter-attribute-clockMode"><att>ttp:clockMode</att></loc> is <code>local</code> or <code>utc</code>.</p>
+</note>
 <p>If a &lt;time-expression&gt; is expressed in terms of a
 <emph>clock-time</emph> and a <emph>frames</emph> term is specified,
 then the value of this term must be constrained to the interval


### PR DESCRIPTION
…58).

Closes #158.