### PR TITLE
Clarify that height of referenced value is used to resolve relative l…

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -13170,11 +13170,13 @@ present, then it denotes the outline color; if no <emph>color</emph> term is
 present, the computed value of the <att>tts:color</att> applies.  The first
 <emph>length</emph> term denotes the outline thickness and the second length
 term, if present, indicates the blur radius.</p>
+<p>When a relative <loc href="#style-value-length">&lt;length&gt;</loc> value is specified for outline thickness or blur radius,
+then it is resolved in terms of the height component of the referenced font size or <loc href="#terms-computed-cell-size">computed cell size</loc>.</p>
 <p>The <loc href="#style-value-length">&lt;length&gt;</loc> value(s) used to express thickness and blur radius must be non-negative.</p>
 <note role="elaboration">
 <p>When a <loc href="#style-value-length">&lt;length&gt;</loc> expressed in
 cells is used in a <att>tts:textOutline</att> value,
-the cell's dimension in the block progression dimension applies.
+the cell's height applies.
 For example, if text outline thickness is specified as 0.1c, the cell resolution
 is 20 by 10, and the extent of the <loc href="#terms-root-container-region">root container region</loc> is 640 by 480, then the
 outline thickness will be a nominal 480 / 10 * 0.1 pixels, i.e., 4.8px,


### PR DESCRIPTION
…engths in tts:textOutline (#217).

Closes #217.