### PR TITLE
Add @ttm:alt as shorthand for ttm:item name="altText" (#490).

### DIFF
--- a/spec/rnc/ttml2-datatypes.rnc
+++ b/spec/rnc/ttml2-datatypes.rnc
@@ -11,6 +11,9 @@ TTAF.Agent.datatype =
 TTAF.Alpha.datatype =
   xsd:float
 
+TTAF.AltText.datatype =
+  string
+
 TTAF.AnimationValue.datatype =
   string
 

--- a/spec/rnc/ttml2-metadata-attribs.rnc
+++ b/spec/rnc/ttml2-metadata-attribs.rnc
@@ -10,6 +10,8 @@ namespace local = ""
 
 TTAF.agent.attrib
   = attribute ttm:agent { TTAF.Agent.datatype }?
+TTAF.alt.attrib
+  = attribute ttm:alt { TTAF.AltText.datatype }?
 TTAF.role.attrib
   = attribute ttm:role { TTAF.Role.datatype }?
 
@@ -17,6 +19,7 @@ TTAF.role.attrib
 
 TTAF.Metadata.attrib.class &=
   TTAF.agent.attrib,
+  TTAF.alt.attrib,
   TTAF.role.attrib
 
 # .......................................................................

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -3337,6 +3337,7 @@ Metadata Attributes
 </td>
 <td>
 <loc href="#metadata-attribute-agent">ttm:agent</loc>,
+<loc href="#metadata-attribute-alt">ttm:alt</loc>,
 <loc href="#metadata-attribute-role">ttm:role</loc>
 </td>
 </tr>
@@ -17203,7 +17204,7 @@ region that is temporally inactive must not produce any visible marks when
 presented on a visual medium.</p>
 <note role="motivation">
 <p>An <loc href="#terms-out-of-line-region">out-of-line</loc> <el>region</el> element may be associated with a time interval for two
-purposes: (1) in order to temporally bound the presentation of the region and
+purposes: (1) in order to temporally bind the presentation of the region and
 its content, and (2) to provide a temporal context in which animations of region
 styles may be effected.</p>
 <p>For example, an author may wish to specify an <loc href="#terms-out-of-line-region">out-of-line</loc> <el>region</el> element that is otherwise empty, but
@@ -19544,6 +19545,7 @@ for use with the <el>metadata</el> element and with certain
 <loc href="#terms-content-element">content element</loc> types:</p>
 <ulist>
 <item><p><specref ref="metadata-attribute-agent"/></p></item>
+<item><p><specref ref="metadata-attribute-alt"/></p></item>
 <item><p><specref ref="metadata-attribute-role"/></p></item>
 </ulist>
 <note role="explanation">
@@ -19565,6 +19567,36 @@ involved in the performance of the content.</p>
 <p>An example of the <att>ttm:agent</att> attribute is shown above in
 <specref ref="metadata-vocabulary-agent-example-1"/>.</p>
 </div3>
+
+<div3 id="metadata-attribute-alt">
+<head>ttm:alt</head>
+<p>The <att>ttm:alt</att> attribute serves as a shorthand expression for an equivalent
+<code>&lt;ttm:item name="altText"/&gt;</code> element, where the value of the attribute
+adheres to <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>.</p>
+<p>If both forms are applied to the same element, then the longhand form, i.e., the <code>&lt;ttm:item name="altText"/&gt;</code> element,
+applies and the shorthand form is ignored.</p>
+<p>The following example depicts equivalent specifications of alternate text to be applied to a given <code>image</code> element.</p>
+<table id="metadata-attribute-alt-example-1" role="example">
+<caption>Example Fragment &ndash; Alternate Text Equivalents</caption>
+<tbody>
+<tr>
+<td>
+<eg xml:space="preserve">
+...
+&lt;image <phrase role="strong">ttm:alt="Alternate Text"</phrase>&gt;
+  &lt;metadata&gt;
+    <phrase role="strong">&lt;ttm:item name="altText"/&gt;Alternate Text&lt;/ttm:item&gt;</phrase>
+  &lt;/metadata&gt;
+&lt;/image&gt;
+...
+</eg>
+</td>
+</tr>
+</tbody>
+</table>
+<p></p>
+</div3>
+
 <div3 id="metadata-attribute-role">
 <head>ttm:role</head>
 <p>The <att>ttm:role</att> attribute may be used by a content author

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -19570,9 +19570,17 @@ involved in the performance of the content.</p>
 
 <div3 id="metadata-attribute-alt">
 <head>ttm:alt</head>
-<p>The <att>ttm:alt</att> attribute serves as a shorthand expression for an equivalent
-<code>&lt;ttm:item name="altText"/&gt;</code> element, where the value of the attribute
+<p>The <att>ttm:alt</att> attribute serves as a shorthand expression for a semantically equivalent
+<code>&lt;ttm:item name="altText"/&gt;</code> element (the longhand form), where the value of this attribute
 adheres to <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>.</p>
+<note role="elaboration">
+  <p>This shorthand form, <att>ttm:alt</att>, cannot be used to represent all <code>&lt;ttm:item name="altText"/&gt;</code> elements; in particular,
+  an <loc href="#content-attribute-xml-lang"><att>xml:lang</att></loc> attribute
+  or <loc href="#content-attribute-xml-space"><att>xml:space</att></loc> attribute (or both attributes) may be associated with the longhand form,
+  but not the shorthand form.</p>
+</note>
+<p>The language identification of the character content of the <att>ttm:alt</att> attribute is the same as the language identification of
+the element on which this attribute is specified.</p>
 <p>If both forms are applied to the same element, then the longhand form, i.e., the <code>&lt;ttm:item name="altText"/&gt;</code> element,
 applies and the shorthand form is ignored.</p>
 <p>The following example depicts equivalent specifications of alternate text to be applied to a given <code>image</code> element.</p>

--- a/spec/xsd/ttml2-datatypes.xsd
+++ b/spec/xsd/ttml2-datatypes.xsd
@@ -14,6 +14,9 @@
   <xs:simpleType name="alpha">
     <xs:restriction base="xs:float"/>
   </xs:simpleType>
+  <xs:simpleType name="altText">
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
   <xs:simpleType name="animationValue">
     <xs:restriction base="xs:string"/>
   </xs:simpleType>

--- a/spec/xsd/ttml2-metadata-attribs.xsd
+++ b/spec/xsd/ttml2-metadata-attribs.xsd
@@ -6,9 +6,11 @@
   <xs:import namespace="http://www.w3.org/ns/ttml#datatype"
     schemaLocation="ttml2-datatypes.xsd"/>
   <xs:attribute name="agent" type="ttd:agent"/>
+  <xs:attribute name="alt" type="ttd:altText"/>
   <xs:attribute name="role" type="ttd:role"/>
   <xs:attributeGroup name="Metadata.attrib.class">
     <xs:attribute ref="ttm:agent"/>
+    <xs:attribute ref="ttm:alt"/>
     <xs:attribute ref="ttm:role"/>
   </xs:attributeGroup>
 </xs:schema>


### PR DESCRIPTION
Closes #490.