### PR TITLE
Remove support for ruby{Overflow,Overhang} (#494).

### DIFF
--- a/spec/profiles/ttml2-full.xml
+++ b/spec/profiles/ttml2-full.xml
@@ -155,9 +155,6 @@
     <feature value="required">#ruby-non-nested-full</feature>
     <feature value="required">#rubyAlign</feature>
     <feature value="required">#rubyOffset</feature>
-    <feature value="required">#rubyOverflow</feature>
-    <feature value="required">#rubyOverhang</feature>
-    <feature value="required">#rubyOverhangClass</feature>
     <feature value="required">#rubyPosition</feature>
     <feature value="required">#rubyReserve</feature>
     <feature value="required">#showBackground</feature>

--- a/spec/profiles/ttml2-presentation.xml
+++ b/spec/profiles/ttml2-presentation.xml
@@ -160,9 +160,6 @@
     <feature value="optional">#ruby-non-nested-full</feature>
     <feature value="optional">#rubyAlign</feature>
     <feature value="optional">#rubyOffset</feature>
-    <feature value="optional">#rubyOverflow</feature>
-    <feature value="optional">#rubyOverhang</feature>
-    <feature value="optional">#rubyOverhangClass</feature>
     <feature value="optional">#rubyPosition</feature>
     <feature value="optional">#rubyReserve</feature>
     <feature value="optional">#showBackground</feature>

--- a/spec/profiles/ttml2-transformation.xml
+++ b/spec/profiles/ttml2-transformation.xml
@@ -162,9 +162,6 @@
     <feature value="optional">#ruby-non-nested-full</feature>
     <feature value="optional">#rubyAlign</feature>
     <feature value="optional">#rubyOffset</feature>
-    <feature value="optional">#rubyOverflow</feature>
-    <feature value="optional">#rubyOverhang</feature>
-    <feature value="optional">#rubyOverhangClass</feature>
     <feature value="optional">#rubyPosition</feature>
     <feature value="optional">#rubyReserve</feature>
     <feature value="optional">#showBackground</feature>

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -3430,9 +3430,6 @@ Styling Attributes
 <loc href="#style-attribute-ruby">tts:ruby</loc>,
 <loc href="#style-attribute-rubyAlign">tts:rubyAlign</loc>,
 <loc href="#style-attribute-rubyOffset">tts:rubyOffset</loc>,
-<loc href="#style-attribute-rubyOverflow">tts:rubyOverflow</loc>,
-<loc href="#style-attribute-rubyOverhang">tts:rubyOverhang</loc>,
-<loc href="#style-attribute-rubyOverhangClass">tts:rubyOverhangClass</loc>,
 <loc href="#style-attribute-rubyPosition">tts:rubyPosition</loc>,
 <loc href="#style-attribute-rubyReserve">tts:rubyReserve</loc>,
 <loc href="#style-attribute-showBackground">tts:showBackground</loc>,
@@ -7961,9 +7958,6 @@ that support inline style specifications:</p>
 <item><p><specref ref="style-attribute-ruby"/></p></item>
 <item><p><specref ref="style-attribute-rubyAlign"/></p></item>
 <item><p><specref ref="style-attribute-rubyOffset"/></p></item>
-<item><p><specref ref="style-attribute-rubyOverflow"/></p></item>
-<item><p><specref ref="style-attribute-rubyOverhang"/></p></item>
-<item><p><specref ref="style-attribute-rubyOverhangClass"/></p></item>
 <item><p><specref ref="style-attribute-rubyPosition"/></p></item>
 <item><p><specref ref="style-attribute-rubyReserve"/></p></item>
 <item><p><specref ref="style-attribute-showBackground"/></p></item>
@@ -12067,6 +12061,26 @@ base delimiter text delimiter =
 <p>The inter-character positioning mode for ruby annotations, such as used with <emph>bopomofo</emph> characters,
 is not supported by this version of this specification due to lack of market requirements.</p>
 </note>
+<div4>
+<head>Special Semantics</head>
+<p>In the absence of implementation specific requirements, constraints on alignment between ruby annotation text and ruby base text that would potentially
+give rise to overflowing a line area should be resolved by shifting ruby annotation text away from the start or end edge of the line area.</p>
+<note role="seealso">
+<p>See <bibref ref="jlreq"/>, &sect;3.3.8, <emph>Adjustments of Ruby with Length Longer than that of the Base Characters</emph>,
+and <bibref ref="cssruby"/>, &sect;5, <emph>Edge Effects</emph>, for further information.</p>
+</note>
+<p>In the absence of implementation specific requirements, ruby annotation text should be allowed to overhang ruby base text only when the
+base text is in any of the following character classes as defined by <bibref ref="jlreq"/>, Appendix A, <emph>Character Classes</emph>:</p>
+<ulist>
+  <item><p><code>hiragana</code></p></item>
+  <item><p><code>ideographic</code></p></item>
+  <item><p><code>punctuationMarks</code></p></item>
+</ulist>
+<note role="seealso">
+<p>See <bibref ref="jlreq"/>, &sect;3.3.8, <emph>Adjustments of Ruby with Length Longer than that of the Base Characters</emph> for
+further information.</p>
+</note>
+</div4>
 </div3>
 <div3 id="style-attribute-rubyAlign">
 <head>tts:rubyAlign</head>
@@ -12310,394 +12324,6 @@ such an offset.</p>
   it appear in the rendered output. In addition, an author would normally not need to specify a <code>tts:rubyOffset</code>
   value equal to <code>0px</code>, since that is the default value of the offset; however, here we specify <code>0px</code>
   for emphasis.</p>
-</note>
-</div3>
-<div3 id="style-attribute-rubyOverflow">
-<head>tts:rubyOverflow</head>
-<p>The <att>tts:rubyOverflow</att> attribute is used to specify constraint resolution rules for handling certain edge effects
-involving ruby text in potential overflow scenarios. For example, if the inline progression dimension of a ruby text area exceeds the
-inline progression dimension of its associated base text, and that base text appears at the start or end edge of a line area, then
-the ruby text may potentially overflow its containing block area depending on the applicable ruby text alignment as determined by
-the <att>tts:rubyAlign</att> style property.</p>
-<p>This attribute may be specified by any element type that permits use of attributes in the TT Style Namespaces; however,
-this attribute applies as a style property only to those element types indicated in the following table.</p>
-<table id="style-property-details-rubyOverflow" role="common">
-<col css="width: 25%;"/>
-<col/>
-<tbody>
-<tr>
-<td><emph>Values:</emph></td>
-<td>
-<code>shiftRuby</code> |
-<code>shiftBase</code> |
-<code>overflow</code>
-</td>
-</tr>
-<tr>
-<td><emph>Initial:</emph></td>
-<td><code>shiftRuby</code></td>
-</tr>
-<tr>
-<td><emph>Applies to:</emph></td>
-<td>
-<loc href="#content-vocabulary-span"><el>span</el></loc> only if the computed value of <loc href="#style-attribute-ruby">tts:ruby</loc> is <code>container</code>.
-</td>
-</tr>
-<tr>
-<td><emph>Inherited:</emph></td>
-<td>yes</td>
-</tr>
-<tr>
-<td><emph>Percentages:</emph></td>
-<td>N/A</td>
-</tr>
-<tr>
-<td><emph>Animatable:</emph></td>
-<td>discrete</td>
-</tr>
-<tr>
-<td><emph>Semantic basis:</emph></td>
-<td><loc href="#derivation-rubyOverflow">rubyOverflow derivation</loc></td>
-</tr>
-</tbody>
-</table>
-<p></p>
-<p>If specified, the value of <att>tts:rubyOverflow</att> expresses how to resolve potential overflow scenarios where ruby text
-may otherwise overflow its containing block in line start or end edge contexts.</p>
-<p>If the value of this attribute is <code>overflow</code>, then ruby text in these line edge contexts is allowed to overflow its containing block,
-in which case the semantics of <att>tts:overflow</att> apply; that is, both base text to line edge alignment and
-ruby text to base text alignment is preserved, while allowing the ruby text to overflow the containing block area.</p>
-<p>If the value of this attribute is <code>shiftBase</code>, then overflow is prevented by relaxing the base text to line edge alignment by
-inseting the base text while preserving ruby text to base alignment.</p>
-<p>If the value of this attribute is <code>shiftRuby</code>, then overflow is prevented by relaxing the ruby text to base text alignment by
-inseting the ruby text while preserving base text to line edge alignment. When inseting ruby text, the semantics of
-<att>tts:overHang</att> apply for the purpose of determining whether and how much overhang is permitted between the inset ruby text and
-adjacent base text.</p>
-<p>When inseting ruby text or base text in order to resolve a potential overflow scenario, only the minimum (non-negative) inset is applied.</p>
-<p>The <att>tts:rubyOverflow</att> style is illustrated by the following example.</p>
-<table id="ruby-overflow-example" role="example">
-<caption>Example Fragment &ndash; Ruby Overflow</caption>
-<tbody>
-<tr>
-<td>
-<eg xml:space="preserve">
-&lt;p region="top"&gt;
-  &lt;span tts:ruby="container" <phrase role="strong">tts:rubyOverflow="overflow"</phrase>&gt;
-    &lt;span tts:ruby="base"&gt;あ&lt;/span&gt;
-    &lt;span tts:ruby="text"&gt;ああああああ&lt;/span&gt;
-  &lt;/span&gt;
-  &lt;span&gt;いうえ&lt;/span&gt;
-&lt;/p&gt;
-&lt;p region="middle"&gt;
-  &lt;span tts:ruby="container" <phrase role="strong">tts:rubyOverflow="shiftRuby"</phrase>&gt;
-    &lt;span tts:ruby="base"&gt;あ&lt;/span&gt;
-    &lt;span tts:ruby="text"&gt;ああああああ&lt;/span&gt;
-  &lt;/span&gt;
-  &lt;span&gt;いうえ&lt;/span&gt;
-&lt;/p&gt;
-&lt;p region="bottom"&gt;
-  &lt;span tts:ruby="container" <phrase role="strong">tts:rubyOverflow="shiftBase"</phrase>&gt;
-    &lt;span tts:ruby="base"&gt;あ&lt;/span&gt;
-    &lt;span tts:ruby="text"&gt;ああああああ&lt;/span&gt;
-  &lt;/span&gt;
-  &lt;span&gt;いうえ&lt;/span&gt;
-&lt;/p&gt;
-</eg>
-</td>
-</tr>
-</tbody>
-</table>
-<p></p>
-<table id="ruby-overflow-example-images" role="example-images">
-<caption>Example Rendition &ndash; Ruby Overflow</caption>
-<tbody>
-<tr>
-<td><graphic source="images/rubyOverflow_final.png" alt="TTML rubyOverflow style property"/></td>
-</tr>
-</tbody>
-</table>
-<note role="elaboration">
-  <p>In the above example, whitespace has been introduced into and around <code>span</code> elements as an aid to formatting;
-  in order to produce the example rendition as shown, it is necessary to remove that extra whitespace lest
-  it appear in the rendered output. The yellow vertical line that appears in each region is the left edge of the region;
-  the first example region shows the effects of allowing ruby text to overflow the region's boundary at this left edge,
-  which corresponds with the start edge of the outer area generated by its content.</p>
-</note>
-<note role="explanation">
-<p>The semantics of the style property represented by this attribute are intended to provide authorial
-control over the special cases of ruby presentation described in
-<bibref ref="jlreq"/>, &sect;3.3.8, <emph>Adjustments of Ruby with Length Longer than that of the Base Characters</emph>,
-and <bibref ref="cssruby"/>, &sect;5, <emph>Edge Effects</emph>.</p>
-</note>
-</div3>
-<div3 id="style-attribute-rubyOverhang">
-<head>tts:rubyOverhang</head>
-<p>The <att>tts:rubyOverhang</att> attribute is used to specify constraint resolution rules for handling potential cases of overhang between
-ruby text and adjacent base text, where by adjacent base text is meant baseline aligned inline content that is immediately adjacent to
-the base text associated with the ruby text. In the case where the inline progression dimension of the ruby text exceeds the
-inline progression dimension of its associated base text, or in ruby overflow cases where the ruby text must be inset, then it is possible
-that the ruby text may overhang content set on the baseline that is not part of the ruby text's associated base text. In such
-cases, the <att>tts:rubyOverhang</att> attribute may be used to determine whether and how much overhang is allowed to occur.</p>
-<p>This attribute may be specified by any element type that permits use of attributes in the TT Style Namespaces; however,
-this attribute applies as a style property only to those element types indicated in the following table.</p>
-<table id="style-property-details-rubyOverhang" role="common">
-<col css="width: 25%;"/>
-<col/>
-<tbody>
-<tr>
-<td><emph>Values:</emph></td>
-<td>
-<code>none</code> |
-<code>allow</code> |
-<code>always</code> |
-<code>overlap</code>
-</td>
-</tr>
-<tr>
-<td><emph>Initial:</emph></td>
-<td><code>allow</code></td>
-</tr>
-<tr>
-<td><emph>Applies to:</emph></td>
-<td>
-<loc href="#content-vocabulary-span"><el>span</el></loc> only if the computed value of <loc href="#style-attribute-ruby">tts:ruby</loc> is
-<code>container</code>.</td>
-</tr>
-<tr>
-<td><emph>Inherited:</emph></td>
-<td>yes</td>
-</tr>
-<tr>
-<td><emph>Percentages:</emph></td>
-<td>N/A</td>
-</tr>
-<tr>
-<td><emph>Animatable:</emph></td>
-<td>discrete</td>
-</tr>
-<tr>
-<td><emph>Semantic basis:</emph></td>
-<td><loc href="#derivation-rubyOverhang">rubyOverhang derivation</loc></td>
-</tr>
-</tbody>
-</table>
-<p></p>
-<p>If specified, the value of <att>tts:rubyOverhang</att> expresses how to resolve potential overhang scenarios where ruby text
-may otherwise overhang adjacent base text.</p>
-<p>If the value of this attribute is <code>none</code>, then overhang is prevented by inserting filler space before and/or after the
-base text associated with the ruby text. When inserting such filler (space), only the minimum (non-negative) filler is applied to prevent overlap.</p>
-<p>If the value of this attribute is <code>allow</code>, then overhang is allowed to occur in accordance with the semantics
-of <att>tts:rubyOverhangClass</att> while preventing overlap between adjacent ruby text containers.</p>
-<p>If the value of this attribute is <code>always</code>, then apply the semantics of <code>allow</code> such that
-the overhang class is the character class containing all characters.</p>
-<p>If the value of this attribute is <code>overlap</code>, then apply the semantics of <code>always</code> except that no filler
-is inserted in order to prevent overlap between adjacent ruby text containers. In this case, the author would need to explcitly insert
-significant white space or filler in order to prevent overlap.</p>
-<p>The <att>tts:rubyOverhang</att> style is illustrated by the following example.</p>
-<table id="ruby-overhang-example" role="example">
-<caption>Example Fragment &ndash; Ruby Overhang</caption>
-<tbody>
-<tr>
-<td>
-<eg xml:space="preserve">
-&lt;p region="top"&gt;
-  &lt;span&gt;因&lt;/span&gt;
-  &lt;span tts:ruby="container" <phrase role="strong">tts:rubyOverhang="overlap"</phrase>&gt;
-    &lt;span tts:ruby="baseContainer"&gt;
-      &lt;span tts:ruby="base"&gt;果&lt;/span&gt;
-      &lt;span tts:ruby="base"&gt;応&lt;/span&gt;
-    &lt;/span&gt;
-    &lt;span tts:ruby="textContainer"&gt;
-      &lt;span tts:ruby="text">果果果果果果&lt;/span&gt;
-      &lt;span tts:ruby="text">応応応応応応&lt;/span&gt;
-    &lt;/span&gt;
-  &lt;/span&gt;
-  &lt;span&gt;報&lt;/span&gt;
-&lt;/p&gt;
-&lt;p region="middle"&gt;
-  &lt;span&gt;因&lt;/span&gt;
-  &lt;span tts:ruby="container" <phrase role="strong">tts:rubyOverhang="always"</phrase>&gt;
-    &lt;span tts:ruby="baseContainer"&gt;
-      &lt;span tts:ruby="base"&gt;果&lt;/span&gt;
-      &lt;span tts:ruby="base"&gt;応&lt;/span&gt;
-    &lt;/span&gt;
-    &lt;span tts:ruby="textContainer"&gt;
-      &lt;span tts:ruby="text">果果果果果果&lt;/span&gt;
-      &lt;span tts:ruby="text">応応応応応応&lt;/span&gt;
-    &lt;/span&gt;
-  &lt;span&gt;報&lt;/span&gt;
-&lt;/p&gt;
-&lt;p region="bottom"&gt;
-  &lt;span&gt;因&lt;/span&gt;
-  &lt;span tts:ruby="container" <phrase role="strong">tts:rubyOverhang="none"</phrase>&gt;
-    &lt;span tts:ruby="baseContainer"&gt;
-      &lt;span tts:ruby="base"&gt;果&lt;/span&gt;
-      &lt;span tts:ruby="base"&gt;応&lt;/span&gt;
-    &lt;/span&gt;
-    &lt;span tts:ruby="textContainer"&gt;
-      &lt;span tts:ruby="text">果果果果果果&lt;/span&gt;
-      &lt;span tts:ruby="text">応応応応応応&lt;/span&gt;
-    &lt;/span&gt;
-  &lt;span&gt;報&lt;/span&gt;
-&lt;/p&gt;
-</eg>
-</td>
-</tr>
-</tbody>
-</table>
-<p></p>
-<table id="ruby-overhang-example-images" role="example-images">
-<caption>Example Rendition &ndash; Ruby Overhang</caption>
-<tbody>
-<tr>
-<td><graphic source="images/rubyOverhang_final.png" alt="TTML rubyOverhang style property"/></td>
-</tr>
-</tbody>
-</table>
-<note role="elaboration">
-  <p>In the above example, whitespace has been introduced into and around <code>span</code> elements as an aid to formatting;
-  in order to produce the example rendition as shown, it is necessary to remove that extra whitespace lest
-  it appear in the rendered output.</p>
-</note>
-<note role="explanation">
-<p>The semantics of the style property represented by this attribute are intended to provide authorial
-control over the special cases of ruby presentation described in
-<bibref ref="jlreq"/>, &sect;3.3.8, <emph>Adjustments of Ruby with Length Longer than that of the Base Characters</emph>,
-and <bibref ref="cssruby"/>, &sect;5, <emph>Edge Effects</emph>.</p>
-</note>
-</div3>
-<div3 id="style-attribute-rubyOverhangClass">
-<head>tts:rubyOverhangClass</head>
-<p>The <att>tts:rubyOverhangClass</att> attribute is used to provide fine-grained control over the semantics of
-the style property expressed by the <att>tts:rubyOverhang</att> attribute. In particular, it used to specify the set
-of base text characters which accept overhanging ruby text. If a base text character is not in this specified set, then ruby
-text is prevented from overhanging that character.</p>
-<p>This attribute may be specified by any element type that permits use of attributes in the TT Style Namespaces; however,
-this attribute applies as a style property only to those element types indicated in the following table.</p>
-<table id="style-property-details-rubyOverhangClass" role="common">
-<col css="width: 25%;"/>
-<col/>
-<tbody>
-<tr>
-<td><emph>Values:</emph></td>
-<td>
-<code>auto</code> |
-(
-<loc href="#style-value-named-character-class">&lt;named-character-class&gt;</loc> |
-<loc href="#style-value-character-class">&lt;character-class&gt;</loc>
-)+
-</td>
-</tr>
-<tr>
-<td><emph>Initial:</emph></td>
-<td><code>auto</code></td>
-</tr>
-<tr>
-<td><emph>Applies to:</emph></td>
-<td>
-<loc href="#content-vocabulary-span"><el>span</el></loc> only if the computed value of <loc href="#style-attribute-ruby">tts:ruby</loc> is
-<code>container</code>.</td>
-</tr>
-<tr>
-<td><emph>Inherited:</emph></td>
-<td>yes</td>
-</tr>
-<tr>
-<td><emph>Percentages:</emph></td>
-<td>N/A</td>
-</tr>
-<tr>
-<td><emph>Animatable:</emph></td>
-<td>discrete</td>
-</tr>
-<tr>
-<td><emph>Semantic basis:</emph></td>
-<td><loc href="#derivation-rubyOverhangClass">rubyOverhangClass derivation</loc></td>
-</tr>
-</tbody>
-</table>
-<p></p>
-<p>If specified, the value of <att>tts:rubyOverhangClass</att> expresses constraints on which base characters allow ruby text to overhang them.</p>
-<p>If the value of this attribute is <code>auto</code>, then the character class that permits overhang is implementation dependent; however, the
-following recommendations apply in the absence of more specific implementation requirements:</p>
-<ulist>
-<item><p>If the language of the base text is specified or can be inferred as Japanese, then <code>auto</code> should be interpreted as if the following
-were specified: <code>ideographic hiragana punctuationMarks</code>.</p></item>
-<item><p>If the language of the base text is specified or can be inferred as Chinese or Korean, then <code>auto</code> should be interpreted as if the
-following were specified: <code>ideographic punctuationMarks</code>.</p></item>
-</ulist>
-<p>If a base character is encountered that is not in the computed value of the <att>tts:rubyOverhangClass</att>, then ruby text must not overhang
-that character.</p>
-<p>The <att>tts:rubyOverhangClass</att> style is illustrated by the following example.</p>
-<table id="ruby-overhang-class-example" role="example">
-<caption>Example Fragment &ndash; Ruby Overhang Class</caption>
-<tbody>
-<tr>
-<td>
-<eg xml:space="preserve">
-&lt;p region="top"&gt;
-  &lt;span&gt;AB&lt;/span&gt;
-  &lt;span tts:ruby="container" <phrase role="strong">tts:rubyOverhangClass="hiragana western"</phrase>&gt;
-    &lt;span tts:ruby="base"&gt;あ&lt;/span&gt;
-    &lt;span tts:ruby="text"&gt;ああああああ&lt;/span&gt;
-  &lt;/span&gt;
-  &lt;span&gt;いう&lt;/span&gt;
-  &lt;span tts:ruby="container" <phrase role="strong">tts:rubyOverhangClass="hiragana western"</phrase>&gt;
-    &lt;span tts:ruby="base"&gt;え&lt;/span&gt;
-    &lt;span tts:ruby="text"&gt;ええええええ&lt;/span&gt;
-  &lt;/span&gt;
-  &lt;span&gt;CD&lt;/span&gt;
-&lt;/p&gt;
-&lt;p region="middle"&gt;
-  &lt;span&gt;AB&lt;/span&gt;
-  &lt;span tts:ruby="container" <phrase role="strong">tts:rubyOverhangClass="hiragana"</phrase>&gt;
-    &lt;span tts:ruby="base"&gt;あ&lt;/span&gt;
-    &lt;span tts:ruby="text"&gt;ああああああ&lt;/span&gt;
-  &lt;/span&gt;
-  &lt;span&gt;いう&lt;/span&gt;
-  &lt;span tts:ruby="container" <phrase role="strong">tts:rubyOverhangClass="hiragana"</phrase>&gt;
-    &lt;span tts:ruby="base"&gt;え&lt;/span&gt;
-    &lt;span tts:ruby="text"&gt;ええええええ&lt;/span&gt;
-  &lt;/span&gt;
-  &lt;span&gt;CD&lt;/span&gt;
-&lt;/p&gt;
-&lt;p region="bottom"&gt;
-  &lt;span&gt;AB&lt;/span&gt;
-  &lt;span tts:ruby="container" <phrase role="strong">tts:rubyOverhangClass="western"</phrase>&gt;
-    &lt;span tts:ruby="base"&gt;あ&lt;/span&gt;
-    &lt;span tts:ruby="text"&gt;ああああああ&lt;/span&gt;
-  &lt;/span&gt;
-  &lt;span&gt;いう&lt;/span&gt;
-  &lt;span tts:ruby="container" <phrase role="strong">tts:rubyOverhangClass="western"</phrase>&gt;
-    &lt;span tts:ruby="base"&gt;え&lt;/span&gt;
-    &lt;span tts:ruby="text"&gt;ええええええ&lt;/span&gt;
-  &lt;/span&gt;
-  &lt;span&gt;CD&lt;/span&gt;
-&lt;/p&gt;
-</eg>
-</td>
-</tr>
-</tbody>
-</table>
-<p></p>
-<table id="ruby-overhang-class-example-images" role="example-images">
-<caption>Example Rendition &ndash; Ruby Overhang Class</caption>
-<tbody>
-<tr>
-<td><graphic source="images/rubyOverhangClass_final.png" alt="TTML rubyOverhangClass style property"/></td>
-</tr>
-</tbody>
-</table>
-<note role="elaboration">
-  <p>In the above example, whitespace has been introduced into and around <code>span</code> elements as an aid to formatting;
-  in order to produce the example rendition as shown, it is necessary to remove that extra whitespace lest
-  it appear in the rendered output.</p>
-</note>
-<note role="explanation">
-<p>The semantics of the style property represented by this attribute are intended to provide authorial
-control over the special cases of ruby presentation described in
-<bibref ref="jlreq"/>, &sect;3.3.8, <emph>Adjustments of Ruby with Length Longer than that of the Base Characters</emph>,
-and <bibref ref="cssruby"/>, &sect;5, <emph>Edge Effects</emph>.</p>
 </note>
 </div3>
 <div3 id="style-attribute-rubyPosition">
@@ -14802,7 +14428,6 @@ character content.</p>
 <item><p><specref ref="style-value-border-radii"/></p></item>
 <item><p><specref ref="style-value-border-style"/></p></item>
 <item><p><specref ref="style-value-border-thickness"/></p></item>
-<item><p><specref ref="style-value-character-class"/></p></item>
 <item><p><specref ref="style-value-color"/></p></item>
 <item><p><specref ref="style-value-digit"/></p></item>
 <item><p><specref ref="style-value-emphasis-color"/></p></item>
@@ -14816,7 +14441,6 @@ character content.</p>
 <item><p><specref ref="style-value-length"/></p></item>
 <item><p><specref ref="style-value-lwsp"/></p></item>
 <item><p><specref ref="style-value-measure"/></p></item>
-<item><p><specref ref="style-value-named-character-class"/></p></item>
 <item><p><specref ref="style-value-named-color"/></p></item>
 <item><p><specref ref="style-value-non-negative-integer"/></p></item>
 <item><p><specref ref="style-value-non-negative-number"/></p></item>
@@ -15062,47 +14686,6 @@ to be implementation dependent; however, the resolved lengths must adhere to the
 constraints: thickness(thin) &lt; thickness(medium); thickness(medium) &lt; thickness(thick).</p>
 <p>If a border thickness is expressed as a <loc href="#style-value-length">&lt;length&gt;</loc>,
 then it must not take the form of a percentage value; i.e., it must take the form of a scalar value.</p>
-</div3>
-<div3 id="style-value-character-class">
-<head>&lt;character-class&gt;</head>
-<p>A &lt;character-class&gt; value is used to express an enumerated set of characters.</p>
-<table id="character-class-style-expression-syntax" role="syntax">
-<caption>Syntax Representation &ndash; &lt;character-class&gt;</caption>
-<tbody>
-<tr>
-<td>
-<eg xml:space="preserve">
-&lt;character-class&gt;
-  : "[" ( class-character-range | class-character )+ "]"
-
-class-character-range
-  : class-character "-" class-character
-
-class-character
-  : unicode-escape
-  | { char - { specials } }
-
-unicode-escape
-  : "\\u" hexDigit{6}
-  | "\\u" hexDigit{4}
-  | "\\" <emph><code>char</code></emph>
-
-specials
-  : "-"
-  | "]"
-  | "\'"
-  | "\""
-  | <loc href="#style-value-whitespace">&lt;whitespace&gt;</loc>
-</eg>
-</td>
-</tr>
-</tbody>
-</table>
-<p>In addition to adhering to the syntax rules specified above, the following semantic rules apply:</p>
-<ulist>
-<item><p>The syntactic element <emph><code>char</code></emph> is to be interpreted according
-to the <code>Char</code> production defined by <bibref ref="xml10"/>&nbsp;&sect;2.2.</p></item>
-</ulist>
 </div3>
 <div3 id="style-value-color">
 <head>&lt;color&gt;</head>
@@ -15643,49 +15226,6 @@ hard, i.e., mandatory, break points, even if that means overflowing the parent's
 </def>
 </gitem>
 </glist>
-</div3>
-<div3 id="style-value-named-character-class">
-<head>&lt;named-character-class&gt;</head>
-<p>A &lt;named-character-class&gt; value is used to express an enumerated character class with a convenient name, where the character class
-is defined by <bibref ref="jlreq"/>, Appendix A, <emph>Character Classes</emph>.</p>
-<p>For the purpose of parsing, a distinction must not be made between lower and upper case.</p>
-<table id="named-character-class-style-expression-syntax" role="syntax">
-<caption>Syntax Representation &ndash; &lt;named-character-class&gt;</caption>
-<tbody>
-<tr>
-<td>
-<eg xml:space="preserve">
-&lt;named-character-class&gt;
-  : "closeBrackets"                         // JLREQ cl-2
-  | "closeWarichu"                          // JLREQ cl-29
-  | "commas"                                // JLREQ cl-7
-  | "fullStops"                             // JLREQ cl-6
-  | "groupedNumerals"                       // JLREQ cl-24
-  | "hiragana"                              // JLREQ cl-15
-  | "hyphens"                               // JLREQ cl-3
-  | "ideographic"                           // JLREQ cl-19
-  | "ideographicSpace"                      // JLREQ cl-14
-  | "inseparables"                          // JLREQ cl-8
-  | "iterationMarks"                        // JLREQ cl-9
-  | "katakana"                              // JLREQ cl-16
-  | "mathOperators"                         // JLREQ cl-18
-  | "mathSymbols"                           // JLREQ cl-17
-  | "middleDots"                            // JLREQ cl-5
-  | "openBrackets"                          // JLREQ cl-1
-  | "openWarichu"                           // JLREQ cl-28
-  | "postAbbreviations"                     // JLREQ cl-13
-  | "preAbbreviations"                      // JLREQ cl-12
-  | "punctuationMarks"                      // JLREQ cl-4
-  | "smallKana"                             // JLREQ cl-11
-  | "soundMarks"                            // JLREQ cl-10
-  | "unitSymbols"                           // JLREQ cl-25
-  | "western"                               // JLREQ cl-27
-  | "westernWordSpace"                      // JLREQ cl-26
-</eg>
-</td>
-</tr>
-</tbody>
-</table>
 </div3>
 <div3 id="style-value-named-color">
 <head>&lt;named-color&gt;</head>
@@ -21787,9 +21327,6 @@ supports the following features:</p>
 <item><p><loc href="#feature-ruby"><code>#ruby</code></loc></p></item>
 <item><p><loc href="#feature-rubyAlign"><code>#rubyAlign</code></loc></p></item>
 <item><p><loc href="#feature-rubyOffset"><code>#rubyOffset</code></loc></p></item>
-<item><p><loc href="#feature-rubyOverflow"><code>#rubyOverflow</code></loc></p></item>
-<item><p><loc href="#feature-rubyOverhang"><code>#rubyOverhang</code></loc></p></item>
-<item><p><loc href="#feature-rubyOverhangClass"><code>#rubyOverhangClass</code></loc></p></item>
 <item><p><loc href="#feature-rubyPosition"><code>#rubyPosition</code></loc></p></item>
 <item><p><loc href="#feature-rubyReserve"><code>#rubyReserve</code></loc></p></item>
 </ulist>
@@ -21824,9 +21361,6 @@ supports the following features:</p>
 <item><p><loc href="#feature-ruby-non-nested"><code>#ruby-non-nested</code></loc></p></item>
 <item><p><loc href="#feature-rubyAlign"><code>#rubyAlign</code></loc></p></item>
 <item><p><loc href="#feature-rubyOffset"><code>#rubyOffset</code></loc></p></item>
-<item><p><loc href="#feature-rubyOverflow"><code>#rubyOverflow</code></loc></p></item>
-<item><p><loc href="#feature-rubyOverhang"><code>#rubyOverhang</code></loc></p></item>
-<item><p><loc href="#feature-rubyOverhangClass"><code>#rubyOverhangClass</code></loc></p></item>
 <item><p><loc href="#feature-rubyPosition"><code>#rubyPosition</code></loc></p></item>
 <item><p><loc href="#feature-rubyReserve"><code>#rubyReserve</code></loc></p></item>
 </ulist>
@@ -21848,33 +21382,6 @@ transforming the <loc href="#style-attribute-rubyOffset"><att>tts:rubyOffset</at
 <p>A TTML <loc href="#terms-presentation-processor">presentation processor</loc> supports the
 <code>#rubyOffset</code> feature if it implements presentation semantic support for the
 <loc href="#style-attribute-rubyOffset"><att>tts:rubyOffset</att></loc> attribute.</p>
-</div3>
-<div3 id="feature-rubyOverflow">
-<head>#rubyOverflow</head>
-<p>A TTML <loc href="#terms-transformation-processor">transformation processor</loc> supports the
-<code>#rubyOverflow</code> feature if it recognizes and is capable of
-transforming the <loc href="#style-attribute-rubyOverflow"><att>tts:rubyOverflow</att></loc> attribute.</p>
-<p>A TTML <loc href="#terms-presentation-processor">presentation processor</loc> supports the
-<code>#rubyOverflow</code> feature if it implements presentation semantic support for the
-<loc href="#style-attribute-rubyOverflow"><att>tts:rubyOverflow</att></loc> attribute.</p>
-</div3>
-<div3 id="feature-rubyOverhang">
-<head>#rubyOverhang</head>
-<p>A TTML <loc href="#terms-transformation-processor">transformation processor</loc> supports the
-<code>#rubyOverhang</code> feature if it recognizes and is capable of
-transforming the <loc href="#style-attribute-rubyOverhang"><att>tts:rubyOverhang</att></loc> attribute.</p>
-<p>A TTML <loc href="#terms-presentation-processor">presentation processor</loc> supports the
-<code>#rubyOverhang</code> feature if it implements presentation semantic support for the
-<loc href="#style-attribute-rubyOverhang"><att>tts:rubyOverhang</att></loc> attribute.</p>
-</div3>
-<div3 id="feature-rubyOverhangClass">
-<head>#rubyOverhangClass</head>
-<p>A TTML <loc href="#terms-transformation-processor">transformation processor</loc> supports the
-<code>#rubyOverhangClass</code> feature if it recognizes and is capable of
-transforming the <loc href="#style-attribute-rubyOverhangClass"><att>tts:rubyOverhangClass</att></loc> attribute.</p>
-<p>A TTML <loc href="#terms-presentation-processor">presentation processor</loc> supports the
-<code>#rubyOverhangClass</code> feature if it implements presentation semantic support for the
-<loc href="#style-attribute-rubyOverhangClass"><att>tts:rubyOverhangClass</att></loc> attribute.</p>
 </div3>
 <div3 id="feature-rubyPosition">
 <head>#rubyPosition</head>
@@ -23432,21 +22939,6 @@ is optional (O), for transformation and <loc href="#terms-presentation-processor
 </tr>
 <tr>
 <td><loc href="#feature-rubyOffset"><code>#rubyOffset</code></loc></td>
-<td>O</td>
-<td>O</td>
-</tr>
-<tr>
-<td><loc href="#feature-rubyOverflow"><code>#rubyOverflow</code></loc></td>
-<td>O</td>
-<td>O</td>
-</tr>
-<tr>
-<td><loc href="#feature-rubyOverhang"><code>#rubyOverhang</code></loc></td>
-<td>O</td>
-<td>O</td>
-</tr>
-<tr>
-<td><loc href="#feature-rubyOverhangClass"><code>#rubyOverhangClass</code></loc></td>
 <td>O</td>
 <td>O</td>
 </tr>
@@ -27483,62 +26975,6 @@ The semantics of this style attribute are extended by this specification.</td>
 </tbody>
 </table>
 </div4>
-<div4 id="derivation-rubyOverhang">
-<head><loc href="#style-attribute-rubyOverhang">tts:rubyOverhang</loc></head>
-<ednote>
-<edtext>Complete when/if a derivation is available, or specify "none"</edtext>
-</ednote><p/>
-<table role="common">
-<col css="width: 20%;"/>
-<col css="width: 80%;"/>
-<tbody>
-<tr>
-<td><phrase role="strong">Reference</phrase></td>
-<td>insert ref</td>
-</tr>
-<tr>
-<td><phrase role="strong">Model</phrase></td>
-<td>insert model</td>
-</tr>
-<tr>
-<td><phrase role="strong">Values</phrase></td>
-<td>insert values</td>
-</tr>
-<tr>
-<td><phrase role="strong">Notes</phrase></td>
-<td>insert notes</td>
-</tr>
-</tbody>
-</table>
-</div4>
-<div4 id="derivation-rubyOverhangClass">
-<head><loc href="#style-attribute-rubyOverhangClass">tts:rubyOverhangClass</loc></head>
-<ednote>
-<edtext>Complete when/if a derivation is available, or specify "none"</edtext>
-</ednote><p/>
-<table role="common">
-<col css="width: 20%;"/>
-<col css="width: 80%;"/>
-<tbody>
-<tr>
-<td><phrase role="strong">Reference</phrase></td>
-<td>insert ref</td>
-</tr>
-<tr>
-<td><phrase role="strong">Model</phrase></td>
-<td>insert model</td>
-</tr>
-<tr>
-<td><phrase role="strong">Values</phrase></td>
-<td>insert values</td>
-</tr>
-<tr>
-<td><phrase role="strong">Notes</phrase></td>
-<td>insert notes</td>
-</tr>
-</tbody>
-</table>
-</div4>
 <div4 id="derivation-rubyPosition">
 <head><loc href="#style-attribute-rubyPosition">tts:rubyPosition</loc></head>
 <ednote>
@@ -28960,9 +28396,6 @@ where <emph>chunking</emph> refers to the subdivision of resource content into c
 <item><p><loc href="#style-attribute-ruby"><att>tts:ruby</att></loc></p></item>
 <item><p><loc href="#style-attribute-rubyAlign"><att>tts:rubyAlign</att></loc></p></item>
 <item><p><loc href="#style-attribute-rubyOffset"><att>tts:rubyOffset</att></loc></p></item>
-<item><p><loc href="#style-attribute-rubyOverflow"><att>tts:rubyOverflow</att></loc></p></item>
-<item><p><loc href="#style-attribute-rubyOverhang"><att>tts:rubyOverhang</att></loc></p></item>
-<item><p><loc href="#style-attribute-rubyOverhangClass"><att>tts:rubyOverhangClass</att></loc></p></item>
 <item><p><loc href="#style-attribute-rubyPosition"><att>tts:rubyPosition</att></loc></p></item>
 <item><p><loc href="#style-attribute-rubyReserve"><att>tts:rubyReserve</att></loc></p></item>
 <item><p><loc href="#style-attribute-textCombine"><att>tts:textCombine</att></loc></p></item>

--- a/spec/xsd/ttml2-datatypes.xsd
+++ b/spec/xsd/ttml2-datatypes.xsd
@@ -568,27 +568,6 @@
     </xs:annotation>
     <xs:restriction base="xs:string"/>
   </xs:simpleType>
-  <xs:simpleType name="rubyOverflow">
-    <xs:restriction base="xs:token">
-      <xs:enumeration value="shiftRuby"/>
-      <xs:enumeration value="shiftBase"/>
-      <xs:enumeration value="overflow"/>
-    </xs:restriction>
-  </xs:simpleType>
-  <xs:simpleType name="rubyOverhang">
-    <xs:restriction base="xs:token">
-      <xs:enumeration value="none"/>
-      <xs:enumeration value="allow"/>
-      <xs:enumeration value="always"/>
-      <xs:enumeration value="overlap"/>
-    </xs:restriction>
-  </xs:simpleType>
-  <xs:simpleType name="rubyOverhangClass">
-    <xs:annotation>
-      <xs:documentation>auto | (characterClassNamed | characterClass)+</xs:documentation>
-    </xs:annotation>
-    <xs:restriction base="xs:string"/>
-  </xs:simpleType>
   <xs:simpleType name="rubyPosition">
     <xs:restriction base="ttd:annotationPosition"/>
   </xs:simpleType>

--- a/spec/xsd/ttml2-styling-attribs.xsd
+++ b/spec/xsd/ttml2-styling-attribs.xsd
@@ -41,9 +41,6 @@
   <xs:attribute name="ruby" type="ttd:ruby"/>
   <xs:attribute name="rubyAlign" type="ttd:rubyAlign"/>
   <xs:attribute name="rubyOffset" type="ttd:rubyOffset"/>
-  <xs:attribute name="rubyOverflow" type="ttd:rubyOverflow"/>
-  <xs:attribute name="rubyOverhang" type="ttd:rubyOverhang"/>
-  <xs:attribute name="rubyOverhangClass" type="ttd:rubyOverhangClass"/>
   <xs:attribute name="rubyPosition" type="ttd:rubyPosition"/>
   <xs:attribute name="rubyReserve" type="ttd:rubyReserve"/>
   <xs:attribute name="script" type="ttd:script"/>
@@ -97,9 +94,6 @@
     <xs:attribute ref="tts:ruby"/>
     <xs:attribute ref="tts:rubyAlign"/>
     <xs:attribute ref="tts:rubyOffset"/>
-    <xs:attribute ref="tts:rubyOverflow"/>
-    <xs:attribute ref="tts:rubyOverhang"/>
-    <xs:attribute ref="tts:rubyOverhangClass"/>
     <xs:attribute ref="tts:rubyPosition"/>
     <xs:attribute ref="tts:rubyReserve"/>
     <xs:attribute ref="tts:script"/>


### PR DESCRIPTION
Closes #494.
Closes #260.
Closes #259.
Closes #257.  