### PR TITLE
Refactor prose defining #textOutline (#430).

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -22238,16 +22238,12 @@ attribute.</p>
 </div3>
 <div3 id="feature-textOutline">
 <head>#textOutline</head>
-<p>A TTML <loc href="#terms-transformation-processor">transformation processor</loc> supports the
-<code>#textOutline</code> feature if it recognizes and is capable of
-transforming the <loc
-href="#style-attribute-textOutline"><att>tts:textOutline</att></loc>
-attribute.</p>
-<p>A TTML <loc href="#terms-presentation-processor">presentation processor</loc> supports the
-<code>#textOutline</code> feature if it implements presentation semantic support
-for the <loc
-href="#style-attribute-textOutline"><att>tts:textOutline</att></loc>
-attribute.</p>
+<p>A TTML processor supports the <code>#textOutline</code> feature if it
+supports the following features:</p>
+<ulist>
+<item><p><loc href="#feature-textOutline-blurred"><code>#textOutline-blurred</code></loc></p></item>
+<item><p><loc href="#feature-textOutline-unblurred"><code>#textOutline-unblurred</code></loc></p></item>
+</ulist>
 </div3>
 <div3 id="feature-textOutline-blurred">
 <head>#textOutline-blurred</head>


### PR DESCRIPTION
Closes #430.