### PR TITLE
Align initial values of tts:origin and tts:position (#551).

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -1539,7 +1539,7 @@ the applicable writing mode.</p>
 about which see also <specref ref="root-container-region-semantics"/>.</p>
 <note role="elaboration">
 <p>The <loc href="#terms-root-container-region">root container region</loc> has no border or padding; consequently, its border, padding, and
-content rectangles (boxes) are coterminous.</p>
+content rectangles are coterminous.</p>
 </note>
 </def>
 </gitem>
@@ -11570,7 +11570,7 @@ a vertical line located at 50% of the width of the posititoning area.</p>
 </tr>
 </tbody>
 </table>
-<p>If specified on a <loc href="#layout-vocabulary-region"><el>region</el></loc> element, then, the positioning rectangle corresponds with the content rectangle (content box) of the <loc href="#terms-root-container-region">root container region</loc>.</p>
+<p>If specified on a <loc href="#layout-vocabulary-region"><el>region</el></loc> element, then, the positioning rectangle corresponds with the content rectangle of the <loc href="#terms-root-container-region">root container region</loc>.</p>
 <p>If a computed value of the property associated with this attribute is not supported,
 then a <loc href="#terms-presentation-processor">presentation processor</loc> must use the closest supported value.</p>
 <note role="elaboration">

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -1537,6 +1537,10 @@ the applicable writing mode.</p>
 <p>A unique, logical, rectangular region that establishes a coordinate system into which
 <loc href="#terms-content-region">content regions</loc> are placed and optionally clipped,
 about which see also <specref ref="root-container-region-semantics"/>.</p>
+<note role="elaboration">
+<p>The <loc href="#terms-root-container-region">root container region</loc> has no border or padding; consequently, its border, padding, and
+content rectangles (boxes) are coterminous.</p>
+</note>
 </def>
 </gitem>
 <gitem id="terms-root-temporal-extent">
@@ -11519,7 +11523,7 @@ then the <att>tts:origin</att> attribute must be ignored for the purpose of pres
 </tr>
 <tr>
 <td><emph>Initial:</emph></td>
-<td><code>center</code></td>
+<td><code>top left</code></td>
 </tr>
 <tr>
 <td><emph>Applies to:</emph></td>
@@ -11566,22 +11570,7 @@ a vertical line located at 50% of the width of the posititoning area.</p>
 </tr>
 </tbody>
 </table>
-<p>If specified on a <loc href="#document-structure-vocabulary-tt"><el>tt</el></loc> element, then, if a
-<loc href="#terms-related-media-object">related media object</loc> exists, the positioning rectangle corresponds with
-the <loc href="#terms-related-media-object-region">related media object region</loc>, or, if no
-<loc href="#terms-related-media-object">related media object</loc> exists, the positioning rectangle corresponds with
-an unspecified presentation region determined by the <loc href="#terms-document-processing-context">document processing context</loc>.
-For other applicable element types, the positioning rectangle corresponds with the content rectangle (content box)
-of the <loc href="#terms-root-container-region">root container region</loc>.</p>
-<note role="elaboration">
-<p>The <loc href="#terms-root-container-region">root container region</loc> has no border or padding; consequently, its border, padding, and
-content rectangles (boxes) are coterminous.</p>
-</note>
-<p>If a horizontal or vertical position offset is specified by a <att>tts:position</att> attribute in the form of a scalar value
-on a <loc href="#document-structure-vocabulary-tt"><el>tt</el></loc> element, then that value must be expressed using pixel (<code>px</code>) units,
-in which case a pixel must be interpreted as a pixel in the
-<loc href="#terms-presentation-context-coordinate-space">presentation context coordinate space</loc>
-(and not a pixel in the <loc href="#terms-document-coordinate-space">document coordinate space</loc>).</p>
+<p>If specified on a <loc href="#layout-vocabulary-region"><el>region</el></loc> element, then, the positioning rectangle corresponds with the content rectangle (content box) of the <loc href="#terms-root-container-region">root container region</loc>.</p>
 <p>If a computed value of the property associated with this attribute is not supported,
 then a <loc href="#terms-presentation-processor">presentation processor</loc> must use the closest supported value.</p>
 <note role="elaboration">


### PR DESCRIPTION
closes #551
align initial values of tts:origin and tts:position
also remove mention of tt element in tts:position, as discussed
In the process of this last part, I had to move a note in the definition of the root container region. 