### PR TITLE
Remove animate, begin, dur, end, region and timeContainer of br elements (#552).

### DIFF
--- a/spec/rnc/ttml2-content.rnc
+++ b/spec/rnc/ttml2-content.rnc
@@ -105,10 +105,7 @@ TTAF.br =
 TTAF.br.attlist &=
   TTAF.Core.attrib.class,
   TTAF.Metadata.attrib.class,
-  TTAF.AnimationBinding.attrib.class,
-  TTAF.RegionBinding.attrib.class,
-  TTAF.Styled.attrib.class,
-  TTAF.TimedContainer.attrib.class
+  TTAF.Styled.attrib.class
 
 TTAF.br.content.extra = empty
 TTAF.br.content =

--- a/spec/ttml2-changes.html
+++ b/spec/ttml2-changes.html
@@ -261,12 +261,6 @@ div.exampleInner { background-color: #d5dee3;
 
 * In 8.1.6, add use of 'xlink:*' attributes to provide linking semantics.
 
-* In 8.1.7, add 'region' attribute to 'br' element.
-
-* In 8.1.7, add timing attributes to 'br' element.
-
-* In 8.1.7, add 'animate' attribute to 'br' element.
-
 * In 8.2, add 'xlink:arcrole', 'xlink:href', 'xlink:role', 'xlink:show', and
   'xlink:title' attributes, applicable to span and image element types.
 
@@ -595,9 +589,6 @@ div.exampleInner { background-color: #d5dee3;
 
 * In 10.4.4.4, rework [filter] step to explicitly enumerate element types
   not filtered.
-
-* In 11.2.1, add 'br' element to list of elements on which region attribute may
-  be specified.
 
 * In 11.3, insert "Inline Regions" as sub-section 9.3.2, renumbering following
   sub-sections.

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -16661,7 +16661,6 @@ element types:</p>
 <item><p><loc href="#content-vocabulary-div"><el>div</el></loc></p></item>
 <item><p><loc href="#content-vocabulary-p"><el>p</el></loc></p></item>
 <item><p><loc href="#content-vocabulary-span"><el>span</el></loc></p></item>
-<item><p><loc href="#content-vocabulary-br"><el>br</el></loc></p></item>
 <item><p><loc href="#embedded-content-vocabulary-image"><el>image</el></loc></p></item>
 </ulist>
 <note role="elaboration">

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -5976,8 +5976,10 @@ an <att>xlink:href</att> attribute, and, if it does, then the latter must be ign
 <p>The <el>br</el> element denotes an explicit line break.</p>
 <p>Any metadata specified by children in the <loc href="#element-vocab-group-metadata"><code>Metadata.class</code></loc>
 element group applies semantically to the <el>br</el> element and its descendants as a whole.</p>
-<p><phrase role="deprecated">The use of <code>Animation.class</code> children is deprecated</phrase> since timing vocabulary does not apply to the 
-<el>br</el> element. Instead, animating a <el>br</el> element can be achieved by wrapping it in an animated <el>span</el> element.</p>
+<p><phrase role="deprecated">The use of <code>Animation.class</code> children is deprecated.</phrase></p>
+<note role="explanation">
+<p>No style attributes apply to <el>br</el> elements therefore animation has no effect on <el>br</el>.</p>
+</note>
 <table id="elt-syntax-br" role="syntax">
 <caption>XML Representation &ndash; Element Information Item: br</caption>
 <tbody>

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -5976,8 +5976,8 @@ an <att>xlink:href</att> attribute, and, if it does, then the latter must be ign
 <p>The <el>br</el> element denotes an explicit line break.</p>
 <p>Any metadata specified by children in the <loc href="#element-vocab-group-metadata"><code>Metadata.class</code></loc>
 element group applies semantically to the <el>br</el> element and its descendants as a whole.</p>
-<p>Any animation elements specified by children in the <loc href="#element-vocab-group-animation"><code>Animation.class</code></loc>
-element group apply semantically to the <el>br</el> element.</p>
+<p><phrase role="deprecated">The use of <code>Animation.class</code> children is deprecated</phrase> since timing vocabulary does not apply to the 
+<el>br</el> element. Instead, animating a <el>br</el> element can be achieved by wrapping it in an animated <el>span</el> element.</p>
 <table id="elt-syntax-br" role="syntax">
 <caption>XML Representation &ndash; Element Information Item: br</caption>
 <tbody>
@@ -5985,14 +5985,8 @@ element group apply semantically to the <el>br</el> element.</p>
 <td>
 <eg xml:space="preserve">
 &lt;br
-  <loc href="#animation-attribute-animate">animate</loc> = IDREFS
-  <loc href="#timing-attribute-begin">begin</loc> = <loc href="#timing-value-time-expression">&lt;time-expression&gt;</loc>
   <loc href="#content-attribute-condition">condition</loc> = <loc href="#content-value-condition">&lt;condition&gt;</loc>
-  <loc href="#timing-attribute-dur">dur</loc> = <loc href="#timing-value-time-expression">&lt;time-expression&gt;</loc>
-  <loc href="#timing-attribute-end">end</loc> = <loc href="#timing-value-time-expression">&lt;time-expression&gt;</loc>
-  <loc href="#layout-attribute-region">region</loc> = IDREF
   <loc href="#style-attribute-style">style</loc> = IDREFS
-  <loc href="#timing-attribute-timeContainer">timeContainer</loc> = (<emph>par</emph>|<emph>seq</emph>)
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -17482,7 +17482,6 @@ has time container semantics, then <code>par</code> time container semantics mus
 <ulist>
 <item><p><loc href="#embedded-content-vocabulary-audio"><el>audio</el></loc></p></item>
 <item><p><loc href="#document-structure-vocabulary-body"><el>body</el></loc></p></item>
-<item><p><loc href="#content-vocabulary-br"><el>br</el></loc></p></item>
 <item><p><loc href="#content-vocabulary-div"><el>div</el></loc></p></item>
 <item><p><loc href="#embedded-content-vocabulary-image"><el>image</el></loc></p></item>
 <item><p><loc href="#content-vocabulary-p"><el>p</el></loc></p></item>

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -6011,9 +6011,6 @@ followed by the control code <code>LF</code> (U+000A) when presented on a telety
 Therefore, two <el>br</el> elements in sequence will produce a
 different effect than a single <el>br</el> element.</p>
 </note>
-<p>If no <att>timeContainer</att> attribute is specified on
-a <el>br</el> element, then it must be interpreted as having
-<emph>parallel</emph> time containment semantics.</p>
 </div3>
 </div2> <!-- content-element-vocabulary -->
 <div2 id="content-attribute-vocabulary">

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -18159,7 +18159,6 @@ element types:</p>
 <ulist>
 <item><p><loc href="#embedded-content-vocabulary-audio"><el>audio</el></loc></p></item>
 <item><p><loc href="#document-structure-vocabulary-body"><el>body</el></loc></p></item>
-<item><p><loc href="#content-vocabulary-br"><el>br</el></loc></p></item>
 <item><p><loc href="#content-vocabulary-div"><el>div</el></loc></p></item>
 <item><p><loc href="#embedded-content-vocabulary-image"><el>image</el></loc></p></item>
 <item><p><loc href="#content-vocabulary-p"><el>p</el></loc></p></item>

--- a/spec/xsd/ttml2-content.xsd
+++ b/spec/xsd/ttml2-content.xsd
@@ -60,9 +60,6 @@
   </xs:attributeGroup>
   <xs:attributeGroup name="br.attlist">
     <xs:attributeGroup ref="tt:Core.attrib.class"/>
-    <xs:attributeGroup ref="tt:TimedContainer.attrib.class"/>
-    <xs:attributeGroup ref="tt:AnimationBinding.attrib.class"/>
-    <xs:attributeGroup ref="tt:RegionBinding.attrib.class"/>
     <xs:attributeGroup ref="tt:Styled.attrib.class"/>
     <xs:attributeGroup ref="ttm:Metadata.attrib.class"/>
   </xs:attributeGroup>


### PR DESCRIPTION
closes #552 

I also checked that `br` is not mentioned in the `Applies to:` section of styling properties and it is not. Quickly looking at the XSD schema it does not look like any change is needed. I am missing anything?