### PR TITLE
Remove mention that dfxp is present in the publication URL (#567).

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -182,8 +182,7 @@ external multimedia integration technology, such as SMIL.</p>
 <note role="historical">
 <p>In previous drafts of this specification, TTML was referred to as DFXP (Distribution
 Format Exchange Profile). This latter term is retained for historical reasons in
-certain contexts, such as profile names and designators, and the short name
-<code>ttaf1-dfxp</code> used in URLs to refer to this specification.</p>
+certain contexts, such as profile names and designators.</p>
 </note>
 <div2 id="model">
 <head>System Model</head>


### PR DESCRIPTION
closes #567 