### PR TITLE
Map measure 'auto' on region to '100%' rather than 'available' (#351).

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -14916,10 +14916,14 @@ interpretation of the specified measure as specified below.</p>
 <gitem>
 <label><code>auto</code></label>
 <def>
-<p>For <emph>ipd</emph>, either (1) the intrinsic size in the <loc href="#terms-inline-progression-direction">inline progression direction</loc>
-when applied to an image, or (2) the numeric value that would be obtained if the <code>available</code> value were specified.
-For <emph>bpd</emph>, either (1) the intrinsic size in the <loc href="#terms-block-progression-direction">block progression direction</loc>
-when applied to an image, or (2) the numeric value that would be obtained if the <code>available</code> value were specified.</p>
+<p>For <emph>ipd</emph>,
+(1) when applied to a <loc href="#terms-region">region</loc>, the numeric value that would be obtained if a value of <code>100%</code> were specified;
+(2) when applied to an image, the intrinsic size in the <loc href="#terms-inline-progression-direction">inline progression direction</loc>; otherwise,
+(3) the numeric value that would be obtained if the <code>available</code> value were specified.</p>
+<p>For <emph>bpd</emph>,
+(1) when applied to a <loc href="#terms-region">region</loc>, the numeric value that would be obtained if a value of <code>100%</code> were specified;
+(2) when applied to an image, the intrinsic size in the <loc href="#terms-block-progression-direction">block progression direction</loc>; otherwise,
+(3) the numeric value that would be obtained if the <code>available</code> value were specified.</p>
 </def>
 </gitem>
 <gitem>


### PR DESCRIPTION
Closes #351.