### PR TITLE
Refactor support for foreign namespace attributes and elements (#439).

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -18420,7 +18420,7 @@ attributes by expressing them indirectly on <el>metadata</el>
 elements.</p>
 </note>
 <note role="clarification"><p>The presence of foreign namespace attributes in a concrete encoding of a TTML
-<loc href="#terms-document-instance">document instance</loc> do not affect the formal validity of that
+<loc href="#terms-document-instance">document instance</loc> does not affect the formal validity of that
 <loc href="#terms-document-instance">document instance</loc> with respect to the applicable
 <loc href="#terms-abstract-document-type">abstract document type</loc> selected by <specref ref="doctypes"/>.</p></note>
 <p>The use of foreign element metadata is illustrated by the following example.</p>
@@ -18450,7 +18450,7 @@ elements.</p>
 Core metadata vocabulary are used to express document level metadata.</p>
 </note>
 <note role="clarification"><p>The presence of foreign namespace elements in a concrete encoding of a TTML
-<loc href="#terms-document-instance">document instance</loc> do not affect the formal validity of that
+<loc href="#terms-document-instance">document instance</loc> does not affect the formal validity of that
 <loc href="#terms-document-instance">document instance</loc> with respect to the applicable
 <loc href="#terms-abstract-document-type">abstract document type</loc> selected by <specref ref="doctypes"/>.</p></note>
 </div3>

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -1875,8 +1875,7 @@ there is a default value, it is shown following a colon. Where an
 <loc href="#terms-attribute-information-item">attribute information item</loc> has a built-in simple type definition
 defined in <bibref ref="xsd-2"/>, a hyperlink to its definition
 therein is given.</p>
-<p>In an XML representation, the expression <emph>{any attribute not in default or any TT Namespace}</emph> applies
-only to namespace qualified attributes; unqualified attributes are not permitted unless explicitly defined in this specification.</p>
+<p>Unqualified attributes are not permitted unless explicitly defined in this specification.</p>
 <p>An information item depicted with a <phrase role="deprecated">light yellow orange</phrase> background color is deprecated (e.g.,
 the <phrase role="deprecated">tiny</phrase> value of the <code>size</code> attribute shown above).
 An information item that is <phrase role="deprecated">deprecated</phrase> may but should not appear in a TTML document instance,
@@ -3602,7 +3601,6 @@ otherwise it is referred to as a <loc href="#terms-non-nesting-profile">non-nest
   type = (processor|content) : processor
   use = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#element-vocab-group-metadata">Metadata.class</loc>*, ((<loc href="#profile-vocabulary-features">ttp:features</loc>*, <loc href="#profile-vocabulary-extensions">ttp:extensions</loc>*)|<loc href="#profile-vocabulary-profile">ttp:profile</loc>*)
 &lt;/ttp:profile&gt;
 </eg>
@@ -3733,7 +3731,6 @@ zero or more <el>ttp:feature</el> elements.</p>
 &lt;ttp:features
   xml:base = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc> : <emph>TT Feature Namespace</emph>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#element-vocab-group-metadata">Metadata.class</loc>*, <loc href="#profile-vocabulary-feature">ttp:feature</loc>*
 &lt;/ttp:features&gt;
 </eg>
@@ -3768,7 +3765,6 @@ infomation about support and usage requirements for a particular feature.</p>
   restricts = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   value = (optional|required|<phrase role="deprecated">use</phrase>|prohibited) : <emph>see prose below</emph>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> #PCDATA
 &lt;/ttp:feature&gt;
 </eg>
@@ -3941,7 +3937,6 @@ zero or more <el>ttp:extension</el> elements.</p>
 &lt;ttp:extensions
   xml:base = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc> : <emph>TT Extension Namespace</emph>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#element-vocab-group-metadata">Metadata.class</loc>*, <loc href="#profile-vocabulary-extension">ttp:extension</loc>*
 &lt;/ttp:extensions&gt;
 </eg>
@@ -3976,7 +3971,6 @@ infomation about support and usage requirements for a particular extension.</p>
   restricts = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   value = (optional|required|<phrase role="deprecated">use</phrase>|prohibited) : <emph>see prose below</emph>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> #PCDATA
 &lt;/ttp:extension&gt;
 </eg>
@@ -5407,7 +5401,6 @@ zero or one <el>body</el> element.</p>
   <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>) : default
   {<emph>any attribute in TT Parameter Namespace</emph>}
   {<emph>any attribute in <termref def="tt-style-namespaces">TT Style Namespaces</termref></emph>}
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#document-structure-vocabulary-head">head</loc>?, <loc href="#document-structure-vocabulary-body">body</loc>?
 &lt;/tt&gt;
 </eg>
@@ -5488,7 +5481,6 @@ or <loc href="#element-vocab-type-layout">Layout</loc> elements.</p>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#element-vocab-group-metadata">Metadata.class</loc>*, <loc href="#element-vocab-group-profile">Profile.class</loc>*, <loc href="#embedded-content-vocabulary-resources">resources</loc>?, <loc href="#styling-vocabulary-styling">styling</loc>?, <loc href="#layout-vocabulary-layout">layout</loc>?, <loc href="#animation-vocabulary-animation">animation</loc>?
 &lt;/head&gt;
 </eg>
@@ -5535,7 +5527,6 @@ element group apply semantically to the <el>body</el> element.</p>
   <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
   {<emph>any attribute in TT Metadata Namespace</emph>}
   {<emph>any attribute in <termref def="tt-style-namespaces">TT Style Namespaces</termref></emph>}
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc
   href="#element-vocab-group-metadata">Metadata.class</loc>*, <loc
   href="#element-vocab-group-animation">Animation.class</loc>*, <loc
@@ -5628,7 +5619,6 @@ element group apply semantically to the <el>div</el> element.</p>
   <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
   {<emph>any attribute in TT Metadata Namespace</emph>}
   {<emph>any attribute in <termref def="tt-style-namespaces">TT Style Namespaces</termref></emph>}
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc
   href="#element-vocab-group-metadata">Metadata.class</loc>*, <loc
   href="#element-vocab-group-animation">Animation.class</loc>*, <loc
@@ -5693,7 +5683,6 @@ element group apply semantically to the <el>p</el> element.</p>
   <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
   {<emph>any attribute in TT Metadata Namespace</emph>}
   {<emph>any attribute in <termref def="tt-style-namespaces">TT Style Namespaces</termref></emph>}
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc
   href="#element-vocab-group-metadata">Metadata.class</loc>*, <loc
   href="#element-vocab-group-animation">Animation.class</loc>*, <loc
@@ -5771,7 +5760,6 @@ element group apply semantically to the <el>span</el> element.</p>
   <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
   {<emph>any attribute in TT Metadata Namespace</emph>}
   {<emph>any attribute in <termref def="tt-style-namespaces">TT Style Namespaces</termref></emph>}
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc
   href="#element-vocab-group-metadata">Metadata.class</loc>*, <loc
   href="#element-vocab-group-animation">Animation.class</loc>*, (<loc
@@ -5828,7 +5816,6 @@ element group apply semantically to the <el>br</el> element.</p>
   <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
   {<emph>any attribute in TT Metadata Namespace</emph>}
   {<emph>any attribute in <termref def="tt-style-namespaces">TT Style Namespaces</termref></emph>}
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#element-vocab-group-metadata">Metadata.class</loc>*, <loc href="#element-vocab-group-animation">Animation.class</loc>*
 &lt;/br&gt;
 </eg>
@@ -6552,7 +6539,6 @@ zero or more elements in the <loc href="#element-vocab-group-animation"><code>An
   <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
   {<emph>any attribute in <termref def="tt-style-namespaces">TT Style Namespaces</termref></emph>}
   {<emph>any attribute in TT Metadata Namespace</emph>}
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#element-vocab-group-metadata">Metadata.class</loc>*, <loc
   href="#element-vocab-group-animation">Animation.class</loc>*, <loc href="#embedded-content-vocabulary-source">source</loc>*
 &lt;/audio&gt;
@@ -6625,7 +6611,6 @@ If no <code>clipEnd</code> attribute is specified, then a value equal to the int
   <loc href="#embedded-content-attribute-encoding">encoding</loc> = (base16|base32|base32hex|base64|base64url) : base64
   length = <loc href="http://www.w3.org/TR/xmlschema-2/#nonNegativeInteger">xsd:nonNegativeInteger</loc>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> #PCDATA
 &lt;/chunk&gt;
 </eg>
@@ -6727,7 +6712,6 @@ contain a <loc href="#embedded-content-vocabulary-data"><el>data</el></loc> elem
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> #PCDATA | (<loc href="#element-vocab-group-metadata">Metadata.class</loc>*, <loc href="#embedded-content-vocabulary-chunk">chunk</loc>+) | (<loc href="#element-vocab-group-metadata">Metadata.class</loc>*, <loc href="#embedded-content-vocabulary-source">source</loc>+)
 &lt;/data&gt;
 </eg>
@@ -6860,7 +6844,6 @@ zero or more elements in the <loc href="#element-vocab-group-metadata"><code>Met
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#element-vocab-group-metadata">Metadata.class</loc>*, <loc href="#embedded-content-vocabulary-source">source</loc>*
 &lt;/font&gt;
 </eg>
@@ -7002,7 +6985,6 @@ zero or more <loc href="#embedded-content-vocabulary-source"><el>source</el></lo
   <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
   {<emph>any attribute in <termref def="tt-style-namespaces">TT Style Namespaces</termref></emph>}
   {<emph>any attribute in TT Metadata Namespace</emph>}
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#element-vocab-group-metadata">Metadata.class</loc>*, <loc
   href="#element-vocab-group-animation">Animation.class</loc>*, <loc href="#embedded-content-vocabulary-source">source</loc>*
 &lt;/image&gt;
@@ -7165,7 +7147,6 @@ followed by zero or more elements in the
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#element-vocab-group-metadata">Metadata.class</loc>*, (<loc href="#element-vocab-group-data">Data.class</loc>|<loc href="#element-vocab-group-embedded">Embedded.class</loc>|<loc href="#element-vocab-group-font">Font.class</loc>)*
 &lt;/resources&gt;
 </eg>
@@ -7207,7 +7188,6 @@ a <loc href="#terms-nested-embedded-source">nested embedded source</loc>.</p>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#element-vocab-group-metadata">Metadata.class</loc>*, <loc href="#embedded-content-vocabulary-data">data</loc>?
 &lt;/source&gt;
 </eg>
@@ -7680,7 +7660,6 @@ the specification defined initial value(s).</p>
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
   {<emph>any attribute in <termref def="tt-style-namespaces">TT Style Namespaces</termref></emph>}
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#element-vocab-group-metadata">Metadata.class</loc>*
 &lt;/initial&gt;
 </eg>
@@ -7729,7 +7708,6 @@ specified style set in accordance with
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
   {<emph>any attribute in <termref def="tt-style-namespaces">TT Style Namespaces</termref></emph>}
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#element-vocab-group-metadata">Metadata.class</loc>*
 &lt;/style&gt;
 </eg>
@@ -7775,7 +7753,6 @@ followed by zero or more <el>style</el> elements.</p>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#element-vocab-group-metadata">Metadata.class</loc>*, <loc href="#styling-vocabulary-initial">initial</loc>*, <loc href="#styling-vocabulary-style">style</loc>*
 &lt;/styling&gt;
 </eg>
@@ -16404,7 +16381,6 @@ zero or more <el>region</el> elements.</p>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#element-vocab-group-metadata">Metadata.class</loc>*, <loc href="#layout-vocabulary-region">region</loc>*
 &lt;/layout&gt;
 </eg>
@@ -16463,7 +16439,6 @@ style inheritance).</p>
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
   {<emph>any attribute in <termref def="tt-style-namespaces">TT Style Namespaces</termref></emph>}
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#element-vocab-group-metadata">Metadata.class</loc>*, <loc href="#element-vocab-group-animation">Animation.class</loc>*, <loc href="#styling-vocabulary-style">style</loc>*
 &lt;/region&gt;
 </eg>
@@ -17798,7 +17773,6 @@ elements in the <loc href="#element-vocab-group-metadata"><code>Metadata.class</
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
   {<emph>any attribute in <termref def="tt-style-namespaces">TT Style Namespaces</termref></emph>}
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#element-vocab-group-metadata">Metadata.class</loc>*
 &lt;/animate&gt;
 </eg>
@@ -17924,7 +17898,6 @@ zero or more elements in the <loc href="#element-vocab-group-animation"><code>An
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#element-vocab-group-metadata">Metadata.class</loc>*, <loc href="#element-vocab-group-animation">Animation.class</loc>*
 &lt;/animation&gt;
 </eg>
@@ -17968,7 +17941,6 @@ elements in the <loc href="#element-vocab-group-metadata"><code>Metadata.class</
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
   {<emph>any attribute in <termref def="tt-style-namespaces">TT Style Namespaces</termref></emph>}
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#element-vocab-group-metadata">Metadata.class</loc>*
 &lt;/set&gt;
 </eg>
@@ -18345,6 +18317,13 @@ information.</p>
 (2) one or more metadata item or foreign namespace child elements,
 (3) one or more <loc href="#embedded-content-vocabulary-data"><el>data</el></loc> child elements, or
 (4) a combination of the preceding.</p>
+<note role="clarification"><p>This specification defines the
+formal validity of a <loc href="#terms-document-instance">document instance</loc> to be based on an
+<loc href="#terms-abstract-document-instance">abstract document instance</loc> from
+which all foreign namespace elements and attributes have been removed. Therefore, the
+following XML Representation does not formally include foreign namespace attributes or foreign namespace child elements in its content model;
+nevertheless, such foreign namespace child elements may appear in a concrete encoding of TTML
+<loc href="#terms-document-instance">document instance</loc>.</p></note>
 <table id="elt-syntax-metadata" role="syntax">
 <caption>XML Representation &ndash; Element Information Item: metadata</caption>
 <tbody>
@@ -18357,8 +18336,7 @@ information.</p>
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
   {<emph>any attribute in TT Metadata Namespace</emph>}
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
-  <emph>Content:</emph> (<loc href="#element-vocab-group-data"><code>Data.class</code></loc>|{<emph>any element in TT Metadata Namespace</emph>}|{<emph>any element not in any TT Namespace</emph>})*
+  <emph>Content:</emph> (<loc href="#element-vocab-group-data"><code>Data.class</code></loc>|{<emph>any element in TT Metadata Namespace</emph>})*
 &lt;/metadata&gt;
 </eg>
 </td>
@@ -18441,7 +18419,10 @@ however, in this case the author wishes to segregate certain metadata
 attributes by expressing them indirectly on <el>metadata</el>
 elements.</p>
 </note>
-<p></p>
+<note role="clarification"><p>The presence of foreign namespace attributes in a concrete encoding of a TTML
+<loc href="#terms-document-instance">document instance</loc> do not affect the formal validity of that
+<loc href="#terms-document-instance">document instance</loc> with respect to the applicable
+<loc href="#terms-abstract-document-type">abstract document type</loc> selected by <specref ref="doctypes"/>.</p></note>
 <p>The use of foreign element metadata is illustrated by the following example.</p>
 <table id="metadata-vocabulary-metadata-example-4" role="example">
 <caption>Example Fragment &ndash; Foreign Element Metadata</caption>
@@ -18468,7 +18449,10 @@ elements.</p>
 <p>In the above example, a number of elements defined by the Dublin
 Core metadata vocabulary are used to express document level metadata.</p>
 </note>
-<p></p>
+<note role="clarification"><p>The presence of foreign namespace elements in a concrete encoding of a TTML
+<loc href="#terms-document-instance">document instance</loc> do not affect the formal validity of that
+<loc href="#terms-document-instance">document instance</loc> with respect to the applicable
+<loc href="#terms-abstract-document-type">abstract document type</loc> selected by <specref ref="doctypes"/>.</p></note>
 </div3>
 <div3 id="metadata-vocabulary-actor">
 <head>ttm:actor</head>
@@ -18486,7 +18470,6 @@ agent with another agent that portrays the character.</p>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> EMPTY
 &lt;/ttm:actor&gt;
 </eg>
@@ -18520,7 +18503,6 @@ agent, whether it be the name of a person, character, group, or organization.</p
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#metadata-vocabulary-name">ttm:name</loc>*, <loc href="#metadata-vocabulary-actor">ttm:actor</loc>?
 &lt;/ttm:agent&gt;
 </eg>
@@ -18616,7 +18598,6 @@ child of the <el>head</el> element.</p>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> #PCDATA
 &lt;/ttm:copyright&gt;
 </eg>
@@ -18643,7 +18624,6 @@ a specific element instance.</p>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> #PCDATA
 &lt;/ttm:desc&gt;
 </eg>
@@ -18676,7 +18656,6 @@ a specific element instance.</p>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> #PCDATA | <loc href="#metadata-vocabulary-item">ttm:item</loc>*
 &lt;/ttm:item&gt;
 </eg>
@@ -18756,7 +18735,6 @@ group, or organization.</p>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> #PCDATA
 &lt;/ttm:name&gt;
 </eg>
@@ -18793,7 +18771,6 @@ a specific element instance.</p>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> #PCDATA
 &lt;/ttm:title&gt;
 </eg>
@@ -23859,7 +23836,6 @@ begin time; furthermore, the temporal intervals of any two child <loc href="#isd
   version = <loc href="http://www.w3.org/TR/xmlschema-2/#positiveInteger">xsd:positiveInteger</loc>
   <loc href="#content-attribute-xml-lang"><phrase role="reqattr">xml:lang</phrase></loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   {<emph>any attribute in the <loc href="#isd-parameter-attribute-set">ISD Parameter Attribute Set</loc></emph>}&gt;
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#metadata-vocabulary-metadata"><el>ttm:metadata</el></loc>*, <loc href="#profile-vocabulary-profile">ttp:profile</loc>?, <loc href="#isd-vocabulary-isd">isd:isd</loc>*
 &lt;/isd:sequence&gt;
 </eg>
@@ -23936,7 +23912,6 @@ followed by zero or more <loc href="#isd-vocabulary-region"><el>isd:region</el><
   version = <loc href="http://www.w3.org/TR/xmlschema-2/#positiveInteger">xsd:positiveInteger</loc>
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   {<emph>any attribute in the <loc href="#isd-parameter-attribute-set">ISD Parameter Attribute Set</loc></emph>}&gt;
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#metadata-vocabulary-metadata"><el>ttm:metadata</el></loc>*, <loc href="#profile-vocabulary-profile">ttp:profile</loc>?, <loc href="#isd-vocabulary-css">isd:css</loc>*, <loc href="#isd-vocabulary-region">isd:region</loc>*
 &lt;/isd:isd&gt;
 </eg>
@@ -23998,7 +23973,6 @@ by an existing <el>isd:css</el> element, then it is assigned a unique identifier
 &lt;isd:css
   <loc href="#content-attribute-xml-id"><phrase role="reqattr">xml:id</phrase></loc> = ID
   {<emph>any attribute in <termref def="tt-style-namespaces">TT Style Namespaces</termref></emph>}
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#metadata-vocabulary-metadata"><el>ttm:metadata</el></loc>*
 &lt;/isd:css&gt;
 </eg>
@@ -24033,7 +24007,6 @@ followed by exactly one <loc href="#document-structure-vocabulary-body"><el>body
   <loc href="#style-attribute-style">style</loc> = IDREF
   <loc href="#metadata-attribute-role">ttm:role</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   <loc href="#content-attribute-xml-id"><phrase role="reqattr">xml:id</phrase></loc> = ID
-  {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#metadata-vocabulary-metadata"><el>ttm:metadata</el></loc>*, <loc href="#animation-vocabulary-animate">animate</loc>*, <loc href="#document-structure-vocabulary-body">body</loc>
 &lt;/isd:region&gt;
 </eg>
@@ -25043,7 +25016,7 @@ followed by optional layout child</td>
 <td><code>svg:metadata</code></td>
 <td><bibref ref="svg11"/></td>
 <td>-@xml:base; +@ttm:*, +@xml:lang, +@xml:space; content model
-subsetted to foreign namespace element content only (no #PCDATA)</td>
+is not mixed (no #PCDATA)</td>
 <td>3,5</td>
 </tr>
 <tr>


### PR DESCRIPTION
Closes #439.

Marking as editorial since it has no impact on conformance.