### PR TITLE
Loosen coupling between usesForced and forced bound parameter (#609).

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -18912,11 +18912,14 @@ provide a textual equivalent or summary for some related image content.</p>
 <gitem id="named-item-usesForced">
 <label><code>usesForced</code></label>
 <def>
-<p>A boolean that expresses whether some <loc href="#content-value-condition">&lt;condition&gt;</loc> expression
-makes use of the <loc href="#bound-parameter-forced"><code>forced</code></loc> bound parameter, where the value
-adheres to <loc href="http://www.w3.org/TR/xmlschema-2/#boolean">xsd:boolean</loc>. If this named metadata item
-is present in a <loc href="#terms-document-instance">document instance</loc>, then it must be specified as a child
-of the <loc href="#document-structure-vocabulary-head"><el>head</el></loc> element.</p>
+<p>A boolean that expresses whether some content within the specifying element's scope makes use of forced display 
+semantics, where the value adheres to <loc href="http://www.w3.org/TR/xmlschema-2/#boolean">xsd:boolean</loc>. 
+If this named metadata item is specified as a child of the <loc href="#document-structure-vocabulary-head"><el>head</el></loc>
+element then the applicable scope is the whole document; if specified as a child of a 
+<loc href="#terms-content-element">content element</loc>, then the applicable scope is that element and its descendants.</p>
+<note role="elaboration">
+<p>Forced display semantics can be expressed by use of the <loc href="#bound-parameter-forced"><code>forced</code></loc>
+bound parameter within a <loc href="#content-value-condition">&lt;condition&gt;</loc> expression.</p></note>
 </def>
 </gitem>
 </glist>


### PR DESCRIPTION
Closes #609 by changing the definition of the usesForced named metadata item in the way proposed there.