### PR TITLE
Clarify the note text around region association (#592).

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -16539,7 +16539,7 @@ which generates out-of-line regions that correspond with the
 explicit inline regions. This latter procedure additionally binds <loc href="#terms-content-element">content elements</loc> associated with inline regions
 to the corresponding generated out-of-line regions.</p>
 <note role="elaboration">
-<p>A <loc href="#terms-content-element">content element</loc> can be directly associated with only a single
+<p>A <loc href="#terms-content-element">content element</loc> can be explicitly associated with only a single
 <loc href="#terms-region">region</loc>, either by an attribute specification or via a child 
 <loc href="#layout-vocabulary-region"><el>region</el></loc> element. Consequently, if a <loc href="#terms-content-element">content element</loc>
 specifies a <loc href="#layout-attribute-region"><att>region</att></loc> attribute, then any 

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -16539,8 +16539,9 @@ which generates out-of-line regions that correspond with the
 explicit inline regions. This latter procedure additionally binds <loc href="#terms-content-element">content elements</loc> associated with inline regions
 to the corresponding generated out-of-line regions.</p>
 <note role="elaboration">
-<p>A <loc href="#terms-content-element">content element</loc> can only be associated with a single
-<loc href="#terms-region">region</loc>. Consequently, if a <loc href="#terms-content-element">content element</loc>
+<p>A <loc href="#terms-content-element">content element</loc> can be directly associated with only a single
+<loc href="#terms-region">region</loc>, either by an attribute specification or via a child 
+<loc href="#layout-vocabulary-region"><el>region</el></loc> element. Consequently, if a <loc href="#terms-content-element">content element</loc>
 specifies a <loc href="#layout-attribute-region"><att>region</att></loc> attribute, then any 
 <emph>explicit inline region specification</emph> is ignored.</p>
 </note>


### PR DESCRIPTION
Closes #592 by editing the note text about region association with a content element to clarify that it refers to direct association via a region attribute or child region element.