### PR TITLE
Quote value syntax keywords (#587).

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -6105,10 +6105,10 @@ argument-list
 <td>
 <eg xml:space="preserve">
 &lt;bound-parameter&gt;
-  : forced
-  | mediaAspectRatio
-  | mediaLanguage
-  | userLanguage
+  : "forced"
+  | "mediaAspectRatio"
+  | "mediaLanguage"
+  | "userLanguage"
 </eg>
 </td>
 </tr>
@@ -7518,10 +7518,10 @@ of <loc href="#terms-font-resource">font resources</loc> due that lack a registe
 <td>
 <eg xml:space="preserve">
 &lt;font-format&gt;
-  : eot                                     // embedded opentype
-  | otf                                     // opentype
-  | ttf                                     // truetype
-  | woff                                    // web open font format
+  : "eot"                                   // embedded opentype
+  | "otf"                                   // opentype
+  | "ttf"                                   // truetype
+  | "woff"                                  // web open font format
   | <loc href="http://www.w3.org/TR/xmlschema-2/#NCName">xsd:NCName</loc>
   | <loc href="#content-value-uri">&lt;uri&gt;</loc>
 </eg>
@@ -7912,9 +7912,9 @@ which the background is painted.</p>
 <tr>
 <td><emph>Values:</emph></td>
 <td>
-<code>border</code> |
-<code>content</code> |
-<code>padding</code>
+<code>"border"</code> |
+<code>"content"</code> |
+<code>"padding"</code>
 </td>
 </tr>
 <tr>
@@ -8190,7 +8190,7 @@ element in a block or inline context.</p>
 <tr>
 <td><emph>Values:</emph></td>
 <td>
-none | <loc href="#embedded-content-value-image">&lt;image&gt;</loc>
+"none" | <loc href="#embedded-content-value-image">&lt;image&gt;</loc>
 </td>
 </tr>
 <tr>
@@ -8302,9 +8302,9 @@ which the background is positioned.</p>
 <tr>
 <td><emph>Values:</emph></td>
 <td>
-<code>border</code> |
-<code>content</code> |
-<code>padding</code>
+<code>"border"</code> |
+<code>"content"</code> |
+<code>"padding"</code>
 </td>
 </tr>
 <tr>
@@ -8468,10 +8468,10 @@ defines whether and how a background image is repeated (tiled) into a region or 
 <tr>
 <td><emph>Values:</emph></td>
 <td>
-<code>repeat</code> |
-<code>repeatX</code> |
-<code>repeatY</code> |
-<code>noRepeat</code>
+<code>"repeat"</code> |
+<code>"repeatX"</code> |
+<code>"repeatY"</code> |
+<code>"noRepeat"</code>
 </td>
 </tr>
 <tr>
@@ -8854,8 +8854,8 @@ about which see <bibref ref="uax9"/>.</p>
 <tr>
 <td><emph>Values:</emph></td>
 <td>
-<code>ltr</code> |
-<code>rtl</code>
+<code>"ltr"</code> |
+<code>"rtl"</code>
 </td>
 </tr>
 <tr>
@@ -9068,9 +9068,9 @@ in a region.</p>
 <tr>
 <td><emph>Values:</emph></td>
 <td>
-<code>auto</code> |
-<code>none</code> |
-<code>inlineBlock</code>
+<code>"auto"</code> |
+<code>"none"</code> |
+<code>"inlineBlock"</code>
 </td>
 </tr>
 <tr>
@@ -9202,10 +9202,10 @@ defines the alignment of block areas in the block progression direction.</p>
 <tr>
 <td><emph>Values:</emph></td>
 <td>
-<code>before</code> |
-<code>center</code> |
-<code>after</code> |
-<code>justify</code>
+<code>"before"</code> |
+<code>"center"</code> |
+<code>"after"</code> |
+<code>"justify"</code>
 </td>
 </tr>
 <tr>
@@ -9590,8 +9590,8 @@ determines whether font kerning is applied when positioning <loc href="#terms-gl
 <tr>
 <td><emph>Values:</emph></td>
 <td>
-<code>none</code> |
-<code>normal</code>
+<code>"none"</code> |
+<code>"normal"</code>
 </td>
 </tr>
 <tr>
@@ -9982,9 +9982,9 @@ by this specification.</p>
 <tr>
 <td><emph>Values:</emph></td>
 <td>
-<code>normal</code> |
-<code>italic</code> |
-<code>oblique</code>
+<code>"normal"</code> |
+<code>"italic"</code> |
+<code>"oblique"</code>
 </td>
 </tr>
 <tr>
@@ -10157,8 +10157,8 @@ by this specification.</p>
 <tr>
 <td><emph>Values:</emph></td>
 <td>
-<code>normal</code> |
-<code>bold</code>
+<code>"normal"</code> |
+<code>"bold"</code>
 </td>
 </tr>
 <tr>
@@ -10319,7 +10319,7 @@ justification may be applied in addition to letter spacing.</p>
 <tr>
 <td><emph>Values:</emph></td>
 <td>
-<code>normal</code> |
+<code>"normal"</code> |
 <loc href="#style-value-length">&lt;length&gt;</loc>
 </td>
 </tr>
@@ -10412,7 +10412,7 @@ horizontal writing modes, but is the horizontal axis in vertical writing modes.<
 <tr>
 <td><emph>Values:</emph></td>
 <td>
-<code>normal</code> |
+<code>"normal"</code> |
 <loc href="#style-value-length">&lt;length&gt;</loc>
 </td>
 </tr>
@@ -10855,8 +10855,8 @@ its extent.</p>
 <tr>
 <td><emph>Values:</emph></td>
 <td>
-<code>visible</code> |
-<code>hidden</code>
+<code>"visible"</code> |
+<code>"hidden"</code>
 </td>
 </tr>
 <tr>
@@ -11274,13 +11274,13 @@ styling.</p>
 <tr>
 <td><emph>Values:</emph></td>
 <td>
-<code>none</code> |
-<code>container</code> |
-<code>base</code> |
-<code>baseContainer</code> |
-<code>text</code> |
-<code>textContainer</code> |
-<code>delimiter</code>
+<code>"none"</code> |
+<code>"container"</code> |
+<code>"base"</code> |
+<code>"baseContainer"</code> |
+<code>"text"</code> |
+<code>"textContainer"</code> |
+<code>"delimiter"</code>
 </td>
 </tr>
 <tr>
@@ -11628,13 +11628,13 @@ further information.</p>
 <tr>
 <td><emph>Values:</emph></td>
 <td>
-<code>auto</code> |
-<code>start</code> |
-<code>center</code> |
-<code>end</code> |
-<code>spaceAround</code> |
-<code>spaceBetween</code> |
-<code>withBase</code>
+<code>"auto"</code> |
+<code>"start"</code> |
+<code>"center"</code> |
+<code>"end"</code> |
+<code>"spaceAround"</code> |
+<code>"spaceBetween"</code> |
+<code>"withBase"</code>
 </td>
 </tr>
 <tr>
@@ -12152,8 +12152,8 @@ if either apply to the region.</p></note>
 <tr>
 <td><emph>Values:</emph></td>
 <td>
-<code>always</code> |
-<code>whenActive</code>
+<code>"always"</code> |
+<code>"whenActive"</code>
 </td>
 </tr>
 <tr>
@@ -12237,12 +12237,12 @@ direction.</p>
 <tr>
 <td><emph>Values:</emph></td>
 <td>
-<code>left</code> |
-<code>center</code> |
-<code>right</code> |
-<code>start</code> |
-<code>end</code> |
-<code>justify</code>
+<code>"left"</code> |
+<code>"center"</code> |
+<code>"right"</code> |
+<code>"start"</code> |
+<code>"end"</code> |
+<code>"justify"</code>
 </td>
 </tr>
 <tr>
@@ -12619,11 +12619,11 @@ by content flowed into a region to which a vertical writing mode applies.</p>
 <tr>
 <td><emph>Values:</emph></td>
 <td>
-<code>mixed</code> |
-<code>sideways</code> |
-<code>sidewaysLeft</code> |
-<code>sidewaysRight</code> |
-<code>upright</code>
+<code>"mixed"</code> |
+<code>"sideways"</code> |
+<code>"sidewaysLeft"</code> |
+<code>"sidewaysRight"</code> |
+<code>"upright"</code>
 </td>
 </tr>
 <tr>
@@ -12922,10 +12922,10 @@ the Unicode bidirectional algorithm.</p>
 <tr>
 <td><emph>Values:</emph></td>
 <td>
-<code>normal</code> |
-<code>embed</code> |
-<code>bidiOverride</code> |
-<code>isolate</code>
+<code>"normal"</code> |
+<code>"embed"</code> |
+<code>"bidiOverride"</code> |
+<code>"isolate"</code>
 </td>
 </tr>
 <tr>
@@ -13014,8 +13014,8 @@ presentation medium.</p>
 <tr>
 <td><emph>Values:</emph></td>
 <td>
-<code>visible</code> |
-<code>hidden</code>
+<code>"visible"</code> |
+<code>"hidden"</code>
 </td>
 </tr>
 <tr>
@@ -13136,8 +13136,8 @@ the affected element.</p>
 <tr>
 <td><emph>Values:</emph></td>
 <td>
-<code>wrap</code> |
-<code>noWrap</code>
+<code>"wrap"</code> |
+<code>"noWrap"</code>
 </td>
 </tr>
 <tr>
@@ -13222,13 +13222,13 @@ stacking block and inline areas within a region area.</p>
 <tr>
 <td><emph>Values:</emph></td>
 <td>
-<code>lrtb</code> |
-<code>rltb</code> |
-<code>tbrl</code> |
-<code>tblr</code> |
-<code>lr</code> |
-<code>rl</code> |
-<code>tb</code>
+<code>"lrtb"</code> |
+<code>"rltb"</code> |
+<code>"tbrl"</code> |
+<code>"tblr"</code> |
+<code>"lr"</code> |
+<code>"rl"</code> |
+<code>"tb"</code>
 </td>
 </tr>
 <tr>
@@ -13317,7 +13317,7 @@ defines the front-to-back ordering of region areas in the case that they overlap
 <tr>
 <td><emph>Values:</emph></td>
 <td>
-<code>auto</code> |
+<code>"auto"</code> |
 <loc href="#style-value-integer">&lt;integer&gt;</loc>
 </td>
 </tr>
@@ -13709,10 +13709,10 @@ determines whether speech synthesis is enabled for the affected content, and, if
 <tr>
 <td><emph>Values:</emph></td>
 <td>
-<code>none</code> |
-<code>normal</code> |
-<code>fast</code> |
-<code>slow</code>
+<code>"none"</code> |
+<code>"normal"</code> |
+<code>"fast"</code> |
+<code>"slow"</code>
 </td>
 </tr>
 <tr>
@@ -13858,7 +13858,7 @@ annotation marks, such as ruby or emphasis marks.</p>
 <td>
 <eg xml:space="preserve">
 &lt;annotation-color&gt;
-  : current
+  : "current"
   | <loc href="#style-value-color">&lt;color&gt;</loc>
 </eg>
 </td>
@@ -13894,9 +13894,9 @@ annotation marks, such as ruby or emphasis marks.</p>
 <td>
 <eg xml:space="preserve">
 &lt;annotation-position&gt;
-  : before
-  | after
-  | outside
+  : "before"
+  | "after"
+  | "outside"
 </eg>
 </td>
 </tr>
@@ -14006,11 +14006,11 @@ or more borders.</p>
 <td>
 <eg xml:space="preserve">
 &lt;border-style&gt;
-  : none
-  | dotted
-  | dashed
-  | solid
-  | double
+  : "none"
+  | "dotted"
+  | "dashed"
+  | "solid"
+  | "double"
 </eg>
 </td>
 </tr>
@@ -14033,9 +14033,9 @@ or more borders.</p>
 <td>
 <eg xml:space="preserve">
 &lt;border-thickness&gt;
-  : thin
-  | medium
-  | thick
+  : "thin"
+  | "medium"
+  | "thick"
   | <loc href="#style-value-length">&lt;length&gt;</loc>
 </eg>
 </td>
@@ -14171,9 +14171,9 @@ emphasis marks.</p>
 <td>
 <eg xml:space="preserve">
 &lt;emphasis-style&gt;
-  : none
-  | auto 
-  | ( filled | open ) || ( circle | dot | sesame )
+  : "none"
+  | "auto" 
+  | ( "filled" | "open" ) || ( "circle" | "dot" | "sesame" )
   | <loc href="#content-value-quoted-string">&lt;quoted-string&gt;</loc>
 </eg>
 </td>
@@ -14249,9 +14249,9 @@ supports text emphasis marks must minimally support the <code>auto</code> value.
 <td>
 <eg xml:space="preserve">
 &lt;extent&gt;
-  : auto
-  | contain
-  | cover
+  : "auto"
+  | "contain"
+  | "cover"
   | <loc href="#style-value-measure">&lt;measure&gt;</loc> <loc href="#style-value-lwsp">&lt;lwsp&gt;</loc> <loc href="#style-value-measure">&lt;measure&gt;</loc>
 </eg>
 </td>
@@ -14390,7 +14390,7 @@ to glyph mapping process, and, specifically, whether and which type of variant g
 <eg xml:space="preserve">
 &lt;font-variant&gt;
   : "normal"
-  | ("super" | "sub") || ("full" | "half") || ruby
+  | ("super" | "sub") || ("full" | "half") || "ruby"
 </eg>
 </td>
 </tr>
@@ -14588,11 +14588,11 @@ interpretation of the specified measure as specified below.</p>
 <td>
 <eg xml:space="preserve">
 &lt;measure&gt;
-  : auto
-  | available
-  | fitContent
-  | maxContent
-  | minContent
+  : "auto"
+  | "available"
+  | "fitContent"
+  | "maxContent"
+  | "minContent"
   | <loc href="#style-value-length">&lt;length&gt;</loc>
 </eg>
 </td>
@@ -14761,7 +14761,7 @@ sign
 <td>
 <eg xml:space="preserve">
 &lt;origin&gt;
-  : auto
+  : "auto"
   | <loc href="#style-value-length">&lt;length&gt;</loc> <loc href="#style-value-lwsp">&lt;lwsp&gt;</loc> <loc
     href="#style-value-length">&lt;length&gt;</loc>
 </eg>
@@ -14821,10 +14821,10 @@ sign
   | sign? <loc href="#style-value-number">&lt;number&gt;</loc> pitch-units?
 
 sign
-  : '+' | '-'
+  : "+" | "-"
 
 pitch-units
-  : 'hz' | 'st'
+  : "hz" | "st"
 </eg>
 </td>
 </tr>
@@ -14875,20 +14875,20 @@ edge-offset-v
   : edge-keyword-v <loc href="#style-value-lwsp">&lt;lwsp&gt;</loc> <loc href="#style-value-length">&lt;length&gt;</loc>
 
 position-keyword-h
-  : center
+  : "center"
   | edge-keyword-h
 
 position-keyword-v
-  : center
+  : "center"
   | edge-keyword-v
 
 edge-keyword-h
-  : left
-  | right
+  : "left"
+  | "right"
 
 edge-keyword-v
-  : top
-  | bottom
+  : "top"
+  | "bottom"
 </eg>
 </td>
 </tr>
@@ -15251,8 +15251,8 @@ In both cases, the resulting difference may be a negative percentage.</p>
 <td>
 <eg xml:space="preserve">
 &lt;ruby-reserve&gt;
-  : none
-  | (auto | before | after | both | outside | around | between) (<loc href="#style-value-lwsp">&lt;lwsp&gt;</loc> <loc href="#style-value-length">&lt;length&gt;</loc>)?
+  : "none"
+  | ("auto" | "before" | "after" | "both" | "outside" | "around" | "between") (<loc href="#style-value-lwsp">&lt;lwsp&gt;</loc> <loc href="#style-value-length">&lt;length&gt;</loc>)?
 </eg>
 </td>
 </tr>
@@ -15310,9 +15310,9 @@ without taking into account rasterization effects.</p>
 <td>
 <eg xml:space="preserve">
 &lt;text-combine&gt;
-  : none
-  | auto
-  | digits (<loc href="#style-value-lwsp">&lt;lwsp&gt;</loc> <loc href="#style-value-non-negative-integer">&lt;non-negative-integer&gt;</loc>)?
+  : "none"
+  | "auto"
+  | "digits" (<loc href="#style-value-lwsp">&lt;lwsp&gt;</loc> <loc href="#style-value-non-negative-integer">&lt;non-negative-integer&gt;</loc>)?
 </eg>
 </td>
 </tr>
@@ -15329,8 +15329,8 @@ without taking into account rasterization effects.</p>
 <td>
 <eg xml:space="preserve">
 &lt;text-decoration&gt;
-  : none
-  | ((underline | noUnderline) || (lineThrough | noLineThrough) || (overline | noOverline))
+  : "none"
+  | (("underline" | "noUnderline") || ("lineThrough" | "noLineThrough") || ("overline" | "noOverline"))
 </eg>
 </td>
 </tr>
@@ -15364,7 +15364,7 @@ without taking into account rasterization effects.</p>
 <td>
 <eg xml:space="preserve">
 &lt;text-outline&gt;
-  : none
+  : "none"
   | (<loc href="#style-value-color">&lt;color&gt;</loc> <loc href="#style-value-lwsp">&lt;lwsp&gt;</loc>)? <loc href="#style-value-length">&lt;length&gt;</loc> (<loc href="#style-value-lwsp">&lt;lwsp&gt;</loc> <loc href="#style-value-length">&lt;length&gt;</loc>)?
 </eg>
 </td>
@@ -15382,7 +15382,7 @@ without taking into account rasterization effects.</p>
 <td>
 <eg xml:space="preserve">
 &lt;text-shadow&gt;
-  : none
+  : "none"
   | <loc href="#style-value-shadow">&lt;shadow&gt;</loc> (<loc href="#style-value-lwsp">&lt;lwsp&gt;</loc> <loc href="#style-value-shadow">&lt;shadow&gt;</loc>)*
 </eg>
 </td>

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -18791,8 +18791,8 @@ a <loc href="#metadata-vocabulary-item"><el>ttm:item</el></loc> element.</p>
 <td>
 <eg xml:space="preserve">
 &lt;named-item&gt;
-  : altText
-  | usesForced
+  : "altText"
+  | "usesForced"
 </eg>
 </td>
 </tr>

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -1862,7 +1862,7 @@ as in the following:</p>
 <eg xml:space="preserve">
 &lt;example
   <phrase role="reqattr">count</phrase> = <loc href="http://www.w3.org/TR/xmlschema-2/#integer">xsd:integer</loc>
-  size = (<emph>large</emph>|<emph>medium</emph>|<emph>small</emph>|<emph><phrase role="deprecated">tiny</phrase></emph>|<emph><phrase role="obsoleted">micro</phrase></emph>) : medium&gt;
+  size = (<emph>"large"</emph> | <emph>"medium"</emph> | <emph>"small"</emph> | <emph><phrase role="deprecated">"tiny"</phrase></emph> | <emph><phrase role="obsoleted">"micro"</phrase></emph>) : medium&gt;
   <emph>Content:</emph> (all | any*)
 &lt;/example&gt;
 </eg>
@@ -2656,13 +2656,13 @@ element</p>
 <gitem id="semantics-profile-state-profile-specification-type">
 <label>type</label>
 <def>
-<p><code>feature|extension</code></p>
+<p><code>"feature" | "extension"</code></p>
 </def>
 </gitem>
 <gitem id="semantics-profile-state-profile-specification-value">
 <label>value</label>
 <def>
-<p><code>optional|required|prohibited</code></p>
+<p><code>"optional" | "required" | "prohibited"</code></p>
 </def>
 </gitem>
 </glist>
@@ -2716,13 +2716,13 @@ that corresponds with a <loc href="#profile-vocabulary-profile"><el>ttp:profile<
 <gitem id="semantics-profile-state-profile-type">
 <label>type</label>
 <def>
-<p><code>content|processor</code></p>
+<p><code>"content" | "processor"</code></p>
 </def>
 </gitem>
 <gitem id="semantics-profile-state-profile-combine">
 <label>combine</label>
 <def>
-<p><code>leastRestrictive|mostRestrictive|replace</code></p>
+<p><code>"leastRestrictive" | "mostRestrictive" | "replace"</code></p>
 </def>
 </gitem>
 <gitem id="semantics-profile-state-profile-use">
@@ -3600,9 +3600,9 @@ otherwise it is referred to as a <loc href="#terms-non-nesting-profile">non-nest
 <td>
 <eg xml:space="preserve">
 &lt;ttp:profile
-  combine = (leastRestrictive|mostRestrictive|replace) : replace
+  combine = (<emph>"leastRestrictive"</emph> | <emph>"mostRestrictive"</emph> | <emph>"replace"</emph>) : replace
   designator = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  type = (processor|content) : processor
+  type = (<emph>"processor"</emph> | <emph>"content"</emph>) : processor
   use = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
@@ -3769,7 +3769,7 @@ infomation about support and usage requirements for a particular feature.</p>
 &lt;ttp:feature
   extends = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   restricts = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  value = (optional|required|<phrase role="deprecated">use</phrase>|prohibited) : <emph>see prose below</emph>
+  value = (<emph>"optional"</emph> | <emph>"required"</emph> | <emph><phrase role="deprecated">"use"</phrase></emph> | <emph>"prohibited"</emph>) : <emph>see prose below</emph>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> #PCDATA
@@ -3977,7 +3977,7 @@ infomation about support and usage requirements for a particular extension.</p>
 &lt;ttp:extension
   extends = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   restricts = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  value = (optional|required|<phrase role="deprecated">use</phrase>|prohibited) : <emph>see prose below</emph>
+  value = (<emph>"optional"</emph> | <emph>"required"</emph> | <emph><phrase role="deprecated">"use"</phrase></emph> | <emph>"prohibited"</emph>) : <emph>see prose below</emph>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> #PCDATA
@@ -5402,7 +5402,7 @@ zero or one <el>body</el> element.</p>
   <loc href="#style-attribute-extent">tts:extent</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang"><phrase role="reqattr">xml:lang</phrase></loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>) : default
+  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>"default"</emph> | <emph>"preserve"</emph>) : default
   {<emph>any attribute in TT Parameter Namespace</emph>}
   {<emph>any attribute in <termref def="tt-style-namespaces">TT Style Namespaces</termref></emph>}
   {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
@@ -5485,7 +5485,7 @@ or <loc href="#element-vocab-type-layout">Layout</loc> elements.</p>
   <loc href="#content-attribute-condition">condition</loc> = <loc href="#content-value-condition">&lt;condition&gt;</loc>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
+  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>"default"</emph> | <emph>"preserve"</emph>)
   {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#element-vocab-group-metadata">Metadata.class</loc>*, <loc href="#element-vocab-group-profile">Profile.class</loc>*, <loc href="#embedded-content-vocabulary-resources">resources</loc>?, <loc href="#styling-vocabulary-styling">styling</loc>?, <loc href="#layout-vocabulary-layout">layout</loc>?, <loc href="#animation-vocabulary-animation">animation</loc>?
 &lt;/head&gt;
@@ -5527,10 +5527,10 @@ element group apply semantically to the <el>body</el> element.</p>
   <loc href="#timing-attribute-end">end</loc> = <loc href="#timing-value-time-expression">&lt;time-expression&gt;</loc>
   <loc href="#layout-attribute-region">region</loc> = IDREF
   <loc href="#style-attribute-style">style</loc> = IDREFS
-  <loc href="#timing-attribute-timeContainer">timeContainer</loc> = (<emph>par</emph>|<emph>seq</emph>)
+  <loc href="#timing-attribute-timeContainer">timeContainer</loc> = (<emph>"par"</emph> | <emph>"seq"</emph>)
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
+  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>"default"</emph> | <emph>"preserve"</emph>)
   {<emph>any attribute in TT Metadata Namespace</emph>}
   {<emph>any attribute in <termref def="tt-style-namespaces">TT Style Namespaces</termref></emph>}
   {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
@@ -5620,10 +5620,10 @@ element group apply semantically to the <el>div</el> element.</p>
   <loc href="#timing-attribute-end">end</loc> = <loc href="#timing-value-time-expression">&lt;time-expression&gt;</loc>
   <loc href="#layout-attribute-region">region</loc> = IDREF
   <loc href="#style-attribute-style">style</loc> = IDREFS
-  <loc href="#timing-attribute-timeContainer">timeContainer</loc> = (<emph>par</emph>|<emph>seq</emph>)
+  <loc href="#timing-attribute-timeContainer">timeContainer</loc> = (<emph>"par"</emph> | <emph>"seq"</emph>)
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
+  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>"default"</emph> | <emph>"preserve"</emph>)
   {<emph>any attribute in TT Metadata Namespace</emph>}
   {<emph>any attribute in <termref def="tt-style-namespaces">TT Style Namespaces</termref></emph>}
   {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
@@ -5685,10 +5685,10 @@ element group apply semantically to the <el>p</el> element.</p>
   <loc href="#timing-attribute-end">end</loc> = <loc href="#timing-value-time-expression">&lt;time-expression&gt;</loc>
   <loc href="#layout-attribute-region">region</loc> = IDREF
   <loc href="#style-attribute-style">style</loc> = IDREFS
-  <loc href="#timing-attribute-timeContainer">timeContainer</loc> = (<emph>par</emph>|<emph>seq</emph>)
+  <loc href="#timing-attribute-timeContainer">timeContainer</loc> = (<emph>"par"</emph> | <emph>"seq"</emph>)
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
+  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>"default"</emph> | <emph>"preserve"</emph>)
   {<emph>any attribute in TT Metadata Namespace</emph>}
   {<emph>any attribute in <termref def="tt-style-namespaces">TT Style Namespaces</termref></emph>}
   {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
@@ -5758,15 +5758,15 @@ element group apply semantically to the <el>span</el> element.</p>
   <loc href="#timing-attribute-end">end</loc> = <loc href="#timing-value-time-expression">&lt;time-expression&gt;</loc>
   <loc href="#layout-attribute-region">region</loc> = IDREF
   <loc href="#style-attribute-style">style</loc> = IDREFS
-  <loc href="#timing-attribute-timeContainer">timeContainer</loc> = (<emph>par</emph>|<emph>seq</emph>)
+  <loc href="#timing-attribute-timeContainer">timeContainer</loc> = (<emph>"par"</emph> | <emph>"seq"</emph>)
   <loc href="#content-attribute-xlink-arcrole">xlink:arcrole</loc> = <loc href="#content-value-uri-list">&lt;uri-list&gt;</loc>
   <loc href="#content-attribute-xlink-href">xlink:href</loc> = <loc href="#content-value-uri">&lt;uri&gt;</loc>
   <loc href="#content-attribute-xlink-role">xlink:role</loc> = <loc href="#content-value-uri-list">&lt;uri-list&gt;</loc>
-  <loc href="#content-attribute-xlink-show">xlink:show</loc> = (<emph>new</emph>|<emph>replace</emph>|<emph>embed</emph>|<emph>other</emph>|<emph>none</emph>) : new
+  <loc href="#content-attribute-xlink-show">xlink:show</loc> = (<emph>"new"</emph> | <emph>"replace"</emph> | <emph>"embed"</emph> | <emph>"other"</emph> | <emph>"none"</emph>) : new
   <loc href="#content-attribute-xlink-title">xlink:title</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
+  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>"default"</emph> | <emph>"preserve"</emph>)
   {<emph>any attribute in TT Metadata Namespace</emph>}
   {<emph>any attribute in <termref def="tt-style-namespaces">TT Style Namespaces</termref></emph>}
   {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
@@ -5819,7 +5819,7 @@ element group applies semantically to the <el>br</el> element and its descendant
   <loc href="#style-attribute-style">style</loc> = IDREFS
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
+  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>"default"</emph> | <emph>"preserve"</emph>)
   {<emph>any attribute in TT Metadata Namespace</emph>}
   {<emph>any attribute in <termref def="tt-style-namespaces">TT Style Namespaces</termref></emph>}
   {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
@@ -6536,11 +6536,11 @@ zero or more elements in the <loc href="#element-vocab-group-animation"><code>An
   <loc href="#embedded-content-attribute-format">format</loc> = <loc href="#embedded-content-value-audio-format">&lt;audio-format&gt;</loc>
   <loc href="#embedded-content-attribute-src">src</loc> = <loc href="#embedded-content-value-audio">&lt;audio&gt;</loc>
   <loc href="#style-attribute-style">style</loc> = IDREFS
-  <loc href="#timing-attribute-timeContainer">timeContainer</loc> = (<emph>par</emph>|<emph>seq</emph>)
+  <loc href="#timing-attribute-timeContainer">timeContainer</loc> = (<emph>"par"</emph> | <emph>"seq"</emph>)
   <loc href="#embedded-content-attribute-type">type</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
+  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>"default"</emph> | <emph>"preserve"</emph>)
   {<emph>any attribute in <termref def="tt-style-namespaces">TT Style Namespaces</termref></emph>}
   {<emph>any attribute in TT Metadata Namespace</emph>}
   {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
@@ -6613,7 +6613,7 @@ If no <code>clipEnd</code> attribute is specified, then a value equal to the int
 <eg xml:space="preserve">
 &lt;chunk
   <loc href="#content-attribute-condition">condition</loc> = <loc href="#content-value-condition">&lt;condition&gt;</loc>
-  <loc href="#embedded-content-attribute-encoding">encoding</loc> = (base16|base32|base32hex|base64|base64url) : base64
+  <loc href="#embedded-content-attribute-encoding">encoding</loc> = (<emph>"base16"</emph> | <emph>"base32"</emph> | <emph>"base32hex"</emph> | <emph>"base64"</emph> | <emph>"base64url"</emph>) : base64
   length = <loc href="http://www.w3.org/TR/xmlschema-2/#nonNegativeInteger">xsd:nonNegativeInteger</loc>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
@@ -6710,14 +6710,14 @@ contain a <loc href="#embedded-content-vocabulary-data"><el>data</el></loc> elem
 <eg xml:space="preserve">
 &lt;data
   <loc href="#content-attribute-condition">condition</loc> = <loc href="#content-value-condition">&lt;condition&gt;</loc>
-  <loc href="#embedded-content-attribute-encoding">encoding</loc> = (base16|base32|base32hex|base64|base64url) : <emph>see prose below</emph>
+  <loc href="#embedded-content-attribute-encoding">encoding</loc> = (<emph>"base16"</emph> | <emph>"base32"</emph> | <emph>"base32hex"</emph> | <emph>"base64"</emph> | <emph>"base64url"</emph>) : <emph>see prose below</emph>
   <loc href="#embedded-content-attribute-format">format</loc> = <loc href="#embedded-content-value-data-format">&lt;data-format&gt;</loc>
   length = <loc href="http://www.w3.org/TR/xmlschema-2/#nonNegativeInteger">xsd:nonNegativeInteger</loc>
   <loc href="#embedded-content-attribute-src">src</loc> = <loc href="#embedded-content-value-data">&lt;data&gt;</loc>
   <loc href="#embedded-content-attribute-type">type</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc> : <emph>see prose below</emph>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
+  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>"default"</emph> | <emph>"preserve"</emph>)
   {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> #PCDATA | (<loc href="#element-vocab-group-metadata">Metadata.class</loc>*, <loc href="#embedded-content-vocabulary-chunk">chunk</loc>+) | (<loc href="#element-vocab-group-metadata">Metadata.class</loc>*, <loc href="#embedded-content-vocabulary-source">source</loc>+)
 &lt;/data&gt;
@@ -6844,13 +6844,13 @@ zero or more elements in the <loc href="#element-vocab-group-metadata"><code>Met
   family = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   <loc href="#embedded-content-attribute-format">format</loc> = <loc href="#embedded-content-value-font-format">&lt;font-format&gt;</loc>
   range = <loc href="#embedded-content-value-unicode-range">&lt;unicode-range&gt;</loc>
-  style = (normal|italic|oblique)
+  style = (<emph>"normal"</emph> | <emph>"italic"</emph> | <emph>"oblique"</emph>) : <emph>see prose below</emph>
   <loc href="#embedded-content-attribute-src">src</loc> = <loc href="#embedded-content-value-font">&lt;font&gt;</loc>
   <loc href="#embedded-content-attribute-type">type</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  weight = (normal|bold)
+  weight = (<emph>"normal"</emph> | <emph>"bold"</emph>) : <emph>see prose below</emph>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
+  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>"default"</emph> | <emph>"preserve"</emph>)
   {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#element-vocab-group-metadata">Metadata.class</loc>*, <loc href="#embedded-content-vocabulary-source">source</loc>*
 &lt;/font&gt;
@@ -6981,16 +6981,16 @@ zero or more <loc href="#embedded-content-vocabulary-source"><el>source</el></lo
   <loc href="#layout-attribute-region">region</loc> = IDREF
   <loc href="#embedded-content-attribute-src">src</loc> = <loc href="#embedded-content-value-image">&lt;image&gt;</loc>
   <loc href="#style-attribute-style">style</loc> = IDREFS
-  <loc href="#timing-attribute-timeContainer">timeContainer</loc> = (<emph>par</emph>|<emph>seq</emph>)
+  <loc href="#timing-attribute-timeContainer">timeContainer</loc> = (<emph>"par"</emph> | <emph>"seq"</emph>)
   <loc href="#embedded-content-attribute-type">type</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   <loc href="#content-attribute-xlink-arcrole">xlink:arcrole</loc> = <loc href="#content-value-uri-list">&lt;uri-list&gt;</loc>
   <loc href="#content-attribute-xlink-href">xlink:href</loc> = <loc href="#content-value-uri">&lt;uri&gt;</loc>
   <loc href="#content-attribute-xlink-role">xlink:role</loc> = <loc href="#content-value-uri-list">&lt;uri-list&gt;</loc>
-  <loc href="#content-attribute-xlink-show">xlink:show</loc> = (<emph>new</emph>|<emph>replace</emph>|<emph>embed</emph>|<emph>other</emph>|<emph>none</emph>) : new
+  <loc href="#content-attribute-xlink-show">xlink:show</loc> = (<emph>"new"</emph> | <emph>"replace"</emph> | <emph>"embed"</emph> | <emph>"other"</emph> | <emph>"none"</emph>) : new
   <loc href="#content-attribute-xlink-title">xlink:title</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
+  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>"default"</emph> | <emph>"preserve"</emph>)
   {<emph>any attribute in <termref def="tt-style-namespaces">TT Style Namespaces</termref></emph>}
   {<emph>any attribute in TT Metadata Namespace</emph>}
   {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
@@ -7155,7 +7155,7 @@ followed by zero or more elements in the
   <loc href="#content-attribute-condition">condition</loc> = <loc href="#content-value-condition">&lt;condition&gt;</loc>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
+  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>"default"</emph> | <emph>"preserve"</emph>)
   {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#element-vocab-group-metadata">Metadata.class</loc>*, (<loc href="#element-vocab-group-data">Data.class</loc>|<loc href="#element-vocab-group-embedded">Embedded.class</loc>|<loc href="#element-vocab-group-font">Font.class</loc>)*
 &lt;/resources&gt;
@@ -7197,7 +7197,7 @@ a <loc href="#terms-nested-embedded-source">nested embedded source</loc>.</p>
   <loc href="#embedded-content-attribute-type">type</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
+  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>"default"</emph> | <emph>"preserve"</emph>)
   {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#element-vocab-group-metadata">Metadata.class</loc>*, <loc href="#embedded-content-vocabulary-data">data</loc>?
 &lt;/source&gt;
@@ -7669,7 +7669,7 @@ the specification defined initial value(s).</p>
   <loc href="#content-attribute-condition">condition</loc> = <loc href="#content-value-condition">&lt;condition&gt;</loc>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
+  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>"default"</emph> | <emph>"preserve"</emph>)
   {<emph>any attribute in <termref def="tt-style-namespaces">TT Style Namespaces</termref></emph>}
   {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#element-vocab-group-metadata">Metadata.class</loc>*
@@ -7718,7 +7718,7 @@ specified style set in accordance with
   <loc href="#style-attribute-style">style</loc> = IDREFS
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
+  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>"default"</emph> | <emph>"preserve"</emph>)
   {<emph>any attribute in <termref def="tt-style-namespaces">TT Style Namespaces</termref></emph>}
   {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#element-vocab-group-metadata">Metadata.class</loc>*
@@ -7765,7 +7765,7 @@ followed by zero or more <el>style</el> elements.</p>
   <loc href="#content-attribute-condition">condition</loc> = <loc href="#content-value-condition">&lt;condition&gt;</loc>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
+  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>"default"</emph> | <emph>"preserve"</emph>)
   {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#element-vocab-group-metadata">Metadata.class</loc>*, <loc href="#styling-vocabulary-initial">initial</loc>*, <loc href="#styling-vocabulary-style">style</loc>*
 &lt;/styling&gt;
@@ -16228,7 +16228,7 @@ zero or more <el>region</el> elements.</p>
   <loc href="#content-attribute-condition">condition</loc> = <loc href="#content-value-condition">&lt;condition&gt;</loc>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
+  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>"default"</emph> | <emph>"preserve"</emph>)
   {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#element-vocab-group-metadata">Metadata.class</loc>*, <loc href="#layout-vocabulary-region">region</loc>*
 &lt;/layout&gt;
@@ -16282,11 +16282,11 @@ style inheritance).</p>
   <loc href="#timing-attribute-dur">dur</loc> = <loc href="#timing-value-time-expression">&lt;time-expression&gt;</loc>
   <loc href="#timing-attribute-end">end</loc> = <loc href="#timing-value-time-expression">&lt;time-expression&gt;</loc>
   <loc href="#style-attribute-style">style</loc> = IDREFS
-  <loc href="#timing-attribute-timeContainer">timeContainer</loc> = (<emph>par</emph>|<emph>seq</emph>)
+  <loc href="#timing-attribute-timeContainer">timeContainer</loc> = (<emph>"par"</emph> | <emph>"seq"</emph>)
   <loc href="#metadata-attribute-role">ttm:role</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
+  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>"default"</emph> | <emph>"preserve"</emph>)
   {<emph>any attribute in <termref def="tt-style-namespaces">TT Style Namespaces</termref></emph>}
   {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#element-vocab-group-metadata">Metadata.class</loc>*, <loc href="#element-vocab-group-animation">Animation.class</loc>*, <loc href="#styling-vocabulary-style">style</loc>*
@@ -17620,7 +17620,7 @@ elements in the <loc href="#element-vocab-group-metadata"><code>Metadata.class</
   <loc href="#style-attribute-style">style</loc> = IDREFS
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
+  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>"default"</emph> | <emph>"preserve"</emph>)
   {<emph>any attribute in <termref def="tt-style-namespaces">TT Style Namespaces</termref></emph>}
   {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#element-vocab-group-metadata">Metadata.class</loc>*
@@ -17747,7 +17747,7 @@ zero or more elements in the <loc href="#element-vocab-group-animation"><code>An
   <loc href="#content-attribute-condition">condition</loc> = <loc href="#content-value-condition">&lt;condition&gt;</loc>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
+  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>"default"</emph> | <emph>"preserve"</emph>)
   {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#element-vocab-group-metadata">Metadata.class</loc>*, <loc href="#element-vocab-group-animation">Animation.class</loc>*
 &lt;/animation&gt;
@@ -17790,7 +17790,7 @@ elements in the <loc href="#element-vocab-group-metadata"><code>Metadata.class</
   <loc href="#style-attribute-style">style</loc> = IDREFS
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
+  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>"default"</emph> | <emph>"preserve"</emph>)
   {<emph>any attribute in <termref def="tt-style-namespaces">TT Style Namespaces</termref></emph>}
   {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#element-vocab-group-metadata">Metadata.class</loc>*
@@ -18178,7 +18178,7 @@ information.</p>
   <loc href="#content-attribute-condition">condition</loc> = <loc href="#content-value-condition">&lt;condition&gt;</loc>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
+  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>"default"</emph> | <emph>"preserve"</emph>)
   {<emph>any attribute in TT Metadata Namespace</emph>}
   {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> (<loc href="#element-vocab-group-data"><code>Data.class</code></loc>|{<emph>any element in TT Metadata Namespace</emph>}|{<emph>any element not in any TT Namespace</emph>})*
@@ -18308,7 +18308,7 @@ agent with another agent that portrays the character.</p>
   <loc href="#content-attribute-condition">condition</loc> = <loc href="#content-value-condition">&lt;condition&gt;</loc>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
+  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>"default"</emph> | <emph>"preserve"</emph>)
   {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> EMPTY
 &lt;/ttm:actor&gt;
@@ -18357,10 +18357,10 @@ agent, whether it be the name of a person, character, group, or organization.</p
 <eg xml:space="preserve">
 &lt;ttm:agent
   <loc href="#content-attribute-condition">condition</loc> = <loc href="#content-value-condition">&lt;condition&gt;</loc>
-  <phrase role="reqattr">type</phrase> = (<emph>person</emph>|<emph>character</emph>|<emph>group</emph>|<emph>organization</emph>|<emph>other</emph>)
+  <phrase role="reqattr">type</phrase> = (<emph>"person"</emph> | <emph>"character"</emph> | <emph>"group"</emph> | <emph>"organization"</emph> | <emph>"other"</emph>)
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
+  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>"default"</emph> | <emph>"preserve"</emph>)
   {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> <loc href="#metadata-vocabulary-name">ttm:name</loc>*, <loc href="#metadata-vocabulary-actor">ttm:actor</loc>?
 &lt;/ttm:agent&gt;
@@ -18456,7 +18456,7 @@ child of the <el>head</el> element.</p>
   <loc href="#content-attribute-condition">condition</loc> = <loc href="#content-value-condition">&lt;condition&gt;</loc>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
+  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>"default"</emph> | <emph>"preserve"</emph>)
   {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> #PCDATA
 &lt;/ttm:copyright&gt;
@@ -18483,7 +18483,7 @@ a specific element instance.</p>
   <loc href="#content-attribute-condition">condition</loc> = <loc href="#content-value-condition">&lt;condition&gt;</loc>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
+  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>"default"</emph> | <emph>"preserve"</emph>)
   {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> #PCDATA
 &lt;/ttm:desc&gt;
@@ -18516,7 +18516,7 @@ a specific element instance.</p>
   <phrase role="reqattr">name</phrase> = <loc href="#metadata-value-item-name">&lt;item-name&gt;</loc>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
+  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>"default"</emph> | <emph>"preserve"</emph>)
   {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> #PCDATA | <loc href="#metadata-vocabulary-item">ttm:item</loc>*
 &lt;/ttm:item&gt;
@@ -18593,10 +18593,10 @@ group, or organization.</p>
 <eg xml:space="preserve">
 &lt;ttm:name
   <loc href="#content-attribute-condition">condition</loc> = <loc href="#content-value-condition">&lt;condition&gt;</loc>
-  <phrase role="reqattr">type</phrase> = (<emph>full</emph>|<emph>family</emph>|<emph>given</emph>|<emph>alias</emph>|<emph>other</emph>)
+  <phrase role="reqattr">type</phrase> = (<emph>"full"</emph> | <emph>"family"</emph> | <emph>"given"</emph> | <emph>"alias"</emph> | <emph>"other"</emph>)
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
+  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>"default"</emph> | <emph>"preserve"</emph>)
   {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> #PCDATA
 &lt;/ttm:name&gt;
@@ -18633,7 +18633,7 @@ a specific element instance.</p>
   <loc href="#content-attribute-condition">condition</loc> = <loc href="#content-value-condition">&lt;condition&gt;</loc>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>default</emph>|<emph>preserve</emph>)
+  <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>"default"</emph> | <emph>"preserve"</emph>)
   {<emph>any attribute not in default or any TT Namespace</emph>}&gt;
   <emph>Content:</emph> #PCDATA
 &lt;/ttm:title&gt;
@@ -23763,7 +23763,7 @@ followed by zero or more <loc href="#isd-vocabulary-region"><el>isd:region</el><
 <eg xml:space="preserve">
 &lt;isd:isd
   <loc href="#timing-attribute-begin"><phrase role="reqattr">begin</phrase></loc> = <loc href="#timing-value-time-expression">&lt;time-expression&gt;</loc>
-  <loc href="#timing-attribute-end"><phrase role="reqattr">end</phrase></loc> = <loc href="#timing-value-time-expression">&lt;time-expression&gt;</loc> | indefinite
+  <loc href="#timing-attribute-end"><phrase role="reqattr">end</phrase></loc> = <loc href="#timing-value-time-expression">&lt;time-expression&gt;</loc> | <emph>"indefinite"</emph>
   version = <loc href="http://www.w3.org/TR/xmlschema-2/#positiveInteger">xsd:positiveInteger</loc>
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   {<emph>any attribute in the <loc href="#isd-parameter-attribute-set">ISD Parameter Attribute Set</loc></emph>}&gt;

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -8190,7 +8190,7 @@ element in a block or inline context.</p>
 <tr>
 <td><emph>Values:</emph></td>
 <td>
-"none" | <loc href="#embedded-content-value-image">&lt;image&gt;</loc>
+<code>"none"</code> | <loc href="#embedded-content-value-image">&lt;image&gt;</loc>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
Closes #587 by quoting all the keywords in the vocabulary definitions.

Opening as a pull request now, however there is an open question about whether keywords need to be quoted in the element XML Representations too. I'm afraid the answer is going to be "yes"...

[updated] ... taking the answer to be "yes".