### PR TITLE
Revert <set> to TTML1 syntax and semantics

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -17776,7 +17776,7 @@ defined to be coterminous with the <loc href="#terms-root-temporal-extent">root 
 </div3>
 <div3 id="animation-vocabulary-set">
 <head>set</head>
-<p>The <el>set</el> element expresses one or more a discrete changes (animations) to be applied (targeted) to style property attributes
+<p>The <el>set</el> element expresses a discrete change (animation) to be applied (targeted) to a style property attribute
 of associated elements.</p>
 <p>A <el>set</el> element may appear as either (1) a child of a
 <loc href="#terms-content-element">content element</loc> or a <loc href="#layout-vocabulary-region"><el>region</el></loc> element,
@@ -17799,13 +17799,11 @@ elements in the <loc href="#element-vocab-group-metadata"><code>Metadata.class</
   <loc href="#content-attribute-condition">condition</loc> = <loc href="#content-value-condition">&lt;condition&gt;</loc>
   <loc href="#timing-attribute-dur">dur</loc> = <loc href="#timing-value-time-expression">&lt;time-expression&gt;</loc>
   <loc href="#timing-attribute-end">end</loc> = <loc href="#timing-value-time-expression">&lt;time-expression&gt;</loc>
-  fill = <loc href="#animation-value-fill">&lt;fill&gt;</loc>
-  repeatCount = <loc href="#animation-value-repeat-count">&lt;repeat-count&gt;</loc>
   <loc href="#style-attribute-style">style</loc> = IDREFS
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
   <loc href="#content-attribute-xml-space">xml:space</loc> = (<emph>"default"</emph> | <emph>"preserve"</emph>)
-  {<emph>any attribute in <termref def="tt-style-namespaces">TT Style Namespaces</termref></emph>}
+  {<emph>a single style property attribute in <termref def="tt-style-namespaces">TT Style Namespaces</termref> or in a namespace that is not some TT Namespace</emph>}
   <emph>Content:</emph> <loc href="#element-vocab-group-metadata">Metadata.class</loc>*
 &lt;/set&gt;
 </eg>
@@ -17813,23 +17811,13 @@ elements in the <loc href="#element-vocab-group-metadata"><code>Metadata.class</
 </tr>
 </tbody>
 </table>
-<p>Style property attributes targeted by an <el>set</el> element are specified directly using
-attributes in the TT Style namespace or in a namespace that is not some TT Namespace, where the single target animation (key) value
-adheres to the <loc href="#animation-value-animation-value-list">&lt;animation-value-list&gt;</loc> syntax, where each
-constituent <loc href="#animation-value-animation-value">&lt;animation-value&gt;</loc> adheres to the syntax of the specified
-attribute, and where exactly one constituent <loc href="#animation-value-animation-value">&lt;animation-value&gt;</loc> is specified.</p>
-<p>If more than one constituent <loc href="#animation-value-animation-value">&lt;animation-value&gt;</loc> is specified, then all
-constituents other than the first must be ignored for the purpose of presentation processing, and must be considered an error for the
-purpose of validation processing.</p>
-<note role="elaboration">
-<p>In contrast with <bibref ref="svg11"/>, &sect;19.2.13, a single <el>set</el> element, as defined here, may be used to
-perform discrete animations on a set of targeted style property attributes instead of being limited to targeting a single style property attribute.
-In <bibref ref="svg11"/>, this would require the use of multiple <el>set</el> elements rather than a single <el>set</el> element.</p>
-</note>
+<p>The style property attribute targeted by a <el>set</el> element is specified directly using an
+attribute in the TT Style namespace or in a namespace that is not some TT Namespace, where the single target animation (key) value
+adheres to the <loc href="#animation-value-animation-value">&lt;animation-value&gt;</loc> syntax.</p>
 <p>Except for the constraints or variations enumerated below, the semantics of the <el>set</el> element and its attributes
 enumerated above are defined to be those specified by <bibref ref="svg11"/>, &sect;19.2.13:</p>
 <olist>
-<item><p>The attributes targeted by a <el>set</el> element and the discrete values to be applied to these attributes are
+<item><p>The attribute targeted by a <el>set</el> element and the discrete value to be applied to this attribute are
 specified by direct use of attributes in the TT Style namespace or in a namespace that is not a TT Namespace (as opposed to using SVG's
 <att>attributeName</att> and <att>to</att> attributes).</p>
 <note role="example">
@@ -17837,7 +17825,6 @@ specified by direct use of attributes in the TT Style namespace or in a namespac
 considered equivalent to specifying <code>attributeName="tts:color"</code> and <code>to="red"</code> in <bibref ref="svg11"/>.</p>
 </note>
 </item>
-<item><p>If no <att>fill</att> attribute is specified, then a <emph>fill</emph> value of <code>remove</code> applies.</p></item>
 </olist>
 <p>An example of using the <el>set</el> element to animate content
 styling is illustrated below:</p>


### PR DESCRIPTION
Remove fill and repeatCount attributes (closes #635)
Revert target style property value to a single value (closes #633)