### PR TITLE
Fixing missing 9 in digit definitions (#642).

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -6295,10 +6295,10 @@ decimal-digits
   | decimal-digits decimal-digit
 
 decimal-digit
-  : "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8"
+  : "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
 
 non-zero-digit
-  : "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8"
+  : "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
 
 exponent-part
   : exponent-indicator signed-integer


### PR DESCRIPTION
closes #642 