### PR TITLE
Add missing at-risk feature to SoTD as resolved (#676).

### DIFF
--- a/spec/status.xml
+++ b/spec/status.xml
@@ -25,6 +25,7 @@ and to encourage implementation by the developer community. This Candidate Recom
 <item><p><loc href="#feature-extent-measure">#extent-measure</loc></p></item>
 <item><p><loc href="#feature-font">#font</loc></p></item>
 <item><p><loc href="#feature-fontSelectionStrategy-character">#fontSelectionStrategy-character</loc></p></item>
+<item><p><loc href="#feature-ipd">#ipd</loc></p></item>
 <item><p><loc href="#feature-rubyAlign-withBase">#rubyAlign-withBase</loc></p></item>
 <item><p><loc href="#feature-textOrientation-sideways-LR">#textOrientation-sideways-LR</loc></p></item>
 <item><p><loc href="#feature-validation">#validation</loc></p></item>


### PR DESCRIPTION
Closes #676.

Add the #ipd feature, which was already agreed for marking at-risk and was inadvertently dropped from PR #669.