### PR TITLE
Fix schema typos and missing specification syntax for definition of '…

### DIFF
--- a/spec/rnc/ttml2-datatypes.rnc
+++ b/spec/rnc/ttml2-datatypes.rnc
@@ -43,7 +43,7 @@ TTAF.Border.datatype =
 TTAF.CalcMode.datatype =
   "discrete" |
   "linear" |
-  "displace" |
+  "paced" |
   "spline"
 
 TTAF.CellResolution.datatype =

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -18107,6 +18107,7 @@ requirements that apply to the attribute targeted by the animation.</p>
 &lt;calculation-mode&gt;
   : "discrete"
   | "linear"
+  | "paced"
   | "spline"
 </eg>
 </td>

--- a/spec/xsd/ttml2-datatypes.xsd
+++ b/spec/xsd/ttml2-datatypes.xsd
@@ -61,7 +61,7 @@
     <xs:restriction base="xs:token">
       <xs:enumeration value="discrete"/>
       <xs:enumeration value="linear"/>
-      <xs:enumeration value="displaced"/>
+      <xs:enumeration value="paced"/>
       <xs:enumeration value="spline"/>
     </xs:restriction>
   </xs:simpleType>


### PR DESCRIPTION
…paced' calculation mode (#699).

Closes #699.