### PR TITLE
Account for use of auto keyword in derivation of tts:textShadow (#726).

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -27528,7 +27528,7 @@ determining the position of underlines applies.</td>
 </tr>
 <tr>
 <td><phrase role="strong">Values</phrase></td>
-<td>Values map directly</td>
+<td>Except for <code>auto</code>, values map directly. The semantics of <code>auto</code> are writing mode dependent.</td>
 </tr>
 <tr>
 <td><phrase role="strong">Notes</phrase></td>


### PR DESCRIPTION
Closes #726.