### PR TITLE
Specify 0px as the default value for blur radius (#721).

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -12955,6 +12955,8 @@ term, if present, indicates the blur radius.</p>
 <p>When a relative <loc href="#style-value-length">&lt;length&gt;</loc> value is specified for outline thickness or blur radius,
 then it is resolved in terms of the height component of the referenced font size or <loc href="#terms-computed-cell-size">computed cell size</loc>.</p>
 <p>The <loc href="#style-value-length">&lt;length&gt;</loc> value(s) used to express thickness and blur radius must be non-negative.</p>
+<p>If no blur radius is specified, i.e., only one <loc href="#style-value-length">&lt;length&gt;</loc> term is present,
+then the computed value of <code>0px</code> applies.</p>
 <note role="elaboration">
 <p>When a <loc href="#style-value-length">&lt;length&gt;</loc> expressed in
 cells is used in a <att>tts:textOutline</att> value,
@@ -15471,6 +15473,8 @@ where positive denotes towards the end edge and negative towards the start edge,
 the second <loc href="#style-value-length">&lt;length&gt;</loc> term denotes the offset in the block progression direction of the associated area,
 where positive denotes towards the after edge and negative towards the before edge.
 The third <loc href="#style-value-length">&lt;length&gt;</loc> term, if present, denotes the blur radius, and must be non-negative.</p>
+<p>If no blur radius is specified, i.e., only two <loc href="#style-value-length">&lt;length&gt;</loc> terms are present,
+then the computed value of <code>0px</code> applies.</p>
 <p>If no <loc href="#style-value-color">&lt;color&gt;</loc> term is
 present, then the computed value of the <att>tts:color</att> property applies.</p>
 <note role="elaboration">


### PR DESCRIPTION
Closes #721.