### PR TITLE
Use COMMA as separator in a list of text shadows (#720).

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -15566,7 +15566,7 @@ without taking into account rasterization effects.</p>
 <eg xml:space="preserve">
 &lt;text-shadow&gt;
   : "none"
-  | <loc href="#style-value-shadow">&lt;shadow&gt;</loc> (<loc href="#style-value-lwsp">&lt;lwsp&gt;</loc> <loc href="#style-value-shadow">&lt;shadow&gt;</loc>)*
+  | <loc href="#style-value-shadow">&lt;shadow&gt;</loc> (<loc href="#style-value-lwsp">&lt;lwsp&gt;</loc>? "," <loc href="#style-value-lwsp">&lt;lwsp&gt;</loc>? <loc href="#style-value-shadow">&lt;shadow&gt;</loc>)*
 </eg>
 </td>
 </tr>


### PR DESCRIPTION
Closes #720.