### PR TITLE
Add ttp:displayAspectRatio (rewriting the now obsolete ttp:storageAsp…

### DIFF
--- a/spec/rnc/ttml2-datatypes.rnc
+++ b/spec/rnc/ttml2-datatypes.rnc
@@ -97,6 +97,9 @@ TTAF.DisplayAlign.datatype =
   "after" |
   "justify"
 
+TTAF.DisplayAspectRatio.datatype =
+  xsd:string { pattern = "\p{Nd}+\s+\p{Nd}+" }
+
 TTAF.DropMode.datatype =
   "dropNTSC" |
   "dropPAL" |
@@ -334,9 +337,6 @@ TTAF.Speak.datatype =
   "fast" |
   "slow"
   
-TTAF.StorageAspectRatio.datatype =
-  xsd:string { pattern = "\p{Nd}+\s+\p{Nd}+" }
-
 TTAF.SubFrameRate.datatype =
   xsd:positiveInteger
 

--- a/spec/rnc/ttml2-isd.rnc
+++ b/spec/rnc/ttml2-isd.rnc
@@ -9,10 +9,10 @@ namespace local = ""
 
 TTAF.isd.parameter.attrib.class &=
   TTAF.cellResolution.attrib,
+  TTAF.displayAspectRatio.attrib,
   TTAF.frameRate.attrib,
   TTAF.frameRateMultiplier.attrib,
   TTAF.pixelAspectRatio.attrib,
-  TTAF.storageAspectRatio.attrib,
   TTAF.subFrameRate.attrib,
   TTAF.tickRate.attrib
 

--- a/spec/rnc/ttml2-parameter-attribs.rnc
+++ b/spec/rnc/ttml2-parameter-attribs.rnc
@@ -14,6 +14,8 @@ TTAF.contentProfiles.attrib
   = attribute ttp:contentProfiles { TTAF.ContentProfiles.datatype }?
 TTAF.contentProfileCombination.attrib
   = attribute ttp:contentProfileCombination { TTAF.ProfileCombination.datatype }?
+TTAF.displayAspectRatio.attrib
+  = attribute ttp:displayAspectRatio { TTAF.DisplayAspectRatio.datatype }?
 TTAF.dropMode.attrib
   = attribute ttp:dropMode { TTAF.DropMode.datatype }?
 TTAF.frameRate.attrib
@@ -38,8 +40,6 @@ TTAF.processorProfileCombination.attrib
   = attribute ttp:processorProfileCombination { TTAF.ProfileCombination.datatype }?
 TTAF.profile.attrib
   = attribute ttp:profile { TTAF.Profile.datatype }?
-TTAF.storageAspectRatio.attrib
-  = attribute ttp:storageAspectRatio { TTAF.StorageAspectRatio.datatype }?
 TTAF.subFrameRate.attrib
   = attribute ttp:subFrameRate { TTAF.SubFrameRate.datatype }?
 TTAF.tickRate.attrib
@@ -58,6 +58,7 @@ TTAF.Parameter.attrib.class &=
   TTAF.clockMode.attrib,
   TTAF.contentProfiles.attrib,
   TTAF.contentProfileCombination.attrib,
+  TTAF.displayAspectRatio.attrib,
   TTAF.dropMode.attrib,
   TTAF.frameRate.attrib,
   TTAF.frameRateMultiplier.attrib,
@@ -70,7 +71,6 @@ TTAF.Parameter.attrib.class &=
   TTAF.processorProfiles.attrib,
   TTAF.processorProfileCombination.attrib,
   TTAF.profile.attrib,
-  TTAF.storageAspectRatio.attrib,
   TTAF.subFrameRate.attrib,
   TTAF.tickRate.attrib,
   TTAF.timeBase.attrib,

--- a/spec/xsd/ttml2-datatypes.xsd
+++ b/spec/xsd/ttml2-datatypes.xsd
@@ -138,6 +138,14 @@
       <xs:enumeration value="justify"/>
     </xs:restriction>
   </xs:simpleType>
+  <xs:simpleType name="displayAspectRatio">
+    <xs:annotation>
+      <xs:documentation>positiveInteger positiveInteger</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="\p{Nd}+\s+\p{Nd}+"/>
+    </xs:restriction>
+  </xs:simpleType>
   <xs:simpleType name="dropMode">
     <xs:restriction base="xs:token">
       <xs:enumeration value="dropNTSC"/>
@@ -542,14 +550,6 @@
     <xs:restriction base="xs:token">
       <xs:enumeration value="always"/>
       <xs:enumeration value="whenActive"/>
-    </xs:restriction>
-  </xs:simpleType>
-  <xs:simpleType name="storageAspectRatio">
-    <xs:annotation>
-      <xs:documentation>positiveInteger:positiveInteger</xs:documentation>
-    </xs:annotation>
-    <xs:restriction base="xs:string">
-      <xs:pattern value="\p{Nd}+\s+\p{Nd}+"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="subFrameRate">

--- a/spec/xsd/ttml2-isd.xsd
+++ b/spec/xsd/ttml2-isd.xsd
@@ -20,10 +20,10 @@
     schemaLocation="xml.xsd"/>
   <xs:attributeGroup name="isd.parameter.attrib.class">
     <xs:attribute ref="ttp:cellResolution"/>
+    <xs:attribute ref="ttp:displayAspectRatio"/>
     <xs:attribute ref="ttp:frameRate"/>
     <xs:attribute ref="ttp:frameRateMultiplier"/>
     <xs:attribute ref="ttp:pixelAspectRatio"/>
-    <xs:attribute ref="ttp:storageAspectRatio"/>
     <xs:attribute ref="ttp:subFrameRate"/>
     <xs:attribute ref="ttp:tickRate"/>
   </xs:attributeGroup>

--- a/spec/xsd/ttml2-parameter-attribs.xsd
+++ b/spec/xsd/ttml2-parameter-attribs.xsd
@@ -9,6 +9,7 @@
   <xs:attribute name="clockMode" type="ttd:clockMode"/>
   <xs:attribute name="contentProfiles" type="ttd:contentProfiles"/>
   <xs:attribute name="contentProfileCombination" type="ttd:profileCombination"/>
+  <xs:attribute name="displayAspectRatio" type="ttd:displayAspectRatio"/>
   <xs:attribute name="dropMode" type="ttd:dropMode"/>
   <xs:attribute name="frameRate" type="ttd:frameRate"/>
   <xs:attribute name="frameRateMultiplier" type="ttd:frameRateMultiplier"/>
@@ -21,7 +22,6 @@
   <xs:attribute name="permitFeatureNarrowing" type="ttd:permitFeatureNarrowingOrWidening"/>
   <xs:attribute name="permitFeatureWidening" type="ttd:permitFeatureNarrowingOrWidening"/>
   <xs:attribute name="profile" type="ttd:profile"/>
-  <xs:attribute name="storageAspectRatio" type="ttd:storageAspectRatio"/>
   <xs:attribute name="subFrameRate" type="ttd:subFrameRate"/>
   <xs:attribute name="tickRate" type="ttd:tickRate"/>
   <xs:attribute name="timeBase" type="ttd:timeBase"/>
@@ -32,6 +32,7 @@
     <xs:attribute ref="ttp:clockMode"/>
     <xs:attribute ref="ttp:contentProfiles"/>
     <xs:attribute ref="ttp:contentProfileCombination"/>
+    <xs:attribute ref="ttp:displayAspectRatio"/>
     <xs:attribute ref="ttp:dropMode"/>
     <xs:attribute ref="ttp:frameRate"/>
     <xs:attribute ref="ttp:frameRateMultiplier"/>
@@ -44,7 +45,6 @@
     <xs:attribute ref="ttp:processorProfiles"/>
     <xs:attribute ref="ttp:processorProfileCombination"/>
     <xs:attribute ref="ttp:profile"/>
-    <xs:attribute ref="ttp:storageAspectRatio"/>
     <xs:attribute ref="ttp:subFrameRate"/>
     <xs:attribute ref="ttp:tickRate"/>
     <xs:attribute ref="ttp:timeBase"/>


### PR DESCRIPTION
…ectRatio) in schemas (#719).

Closes #719.

Marked editorial since spec already changed, but schemas were merely lagging behind the spec.