### PR TITLE
Fix placement typo (wrong location of exclusion language) (#688).

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -21223,6 +21223,8 @@ transforming the <loc href="#style-attribute-rubyAlign"><att>tts:rubyAlign</att>
 <p>A TTML <loc href="#terms-presentation-processor">presentation processor</loc> supports the
 <code>#rubyAlign</code> feature if it implements presentation semantic support for the
 <loc href="#style-attribute-rubyAlign"><att>tts:rubyAlign</att></loc> attribute.</p>
+<p>Notwithstanding the above, support for the <code>#rubyAlign</code> feature does not require support for the
+<loc href="#feature-rubyAlign-withBase"><code>#rubyAlign-withBase</code></loc> feature.</p>
 </div3>
 <div3 id="feature-rubyAlign-withBase">
 <head>#rubyAlign-withBase</head>
@@ -21232,8 +21234,6 @@ transforming the <loc href="#style-attribute-rubyAlign"><att>tts:rubyAlign</att>
 <p>A TTML <loc href="#terms-presentation-processor">presentation processor</loc> supports the
 <code>#rubyAlign-withBase</code> feature if it implements presentation semantic support for the
 <code>withBase</code> value of the <loc href="#style-attribute-rubyAlign"><att>tts:rubyAlign</att></loc> attribute.</p>
-<p>Notwithstanding the above, support for the <code>#rubyAlign</code> feature does not require support for the
-<loc href="#feature-rubyAlign-withBase"><code>#rubyAlign-withBase</code></loc> feature.</p>
 </div3>
 <div3 id="feature-rubyPosition">
 <head>#rubyPosition</head>


### PR DESCRIPTION
Closes #688.