### PR TITLE
Fix typo in rubyReserve.

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -12508,7 +12508,7 @@ with the <loc href="#style-attribute-fontSize"><att>tts:fontSize</att></loc> att
 actually present in a <loc href="#content-vocabulary-p"><el>p</el></loc> element.</p>
 <p>If no length component is specified, then it must be considered to be equal to the value of the style property associated with the
 <loc href="#style-attribute-fontSize"><att>tts:fontSize</att></loc> attribute that would be inherited by
-a hypothetical <emph>ruby text container</emph> or <emph>ruby text content</emph>, where such content actually present
+a hypothetical <emph>ruby text container</emph> or <emph>ruby text content</emph>, were such content actually present
 in a <loc href="#content-vocabulary-p"><el>p</el></loc> element, where the semantics of
 <specref ref="style-attribute-fontSize-special-semantics"/> apply for the purpose of computing this inherited value.</p>
 <p>If the <loc href="#style-value-length">&lt;length&gt;</loc> component is specified, it must be non-negative.</p>


### PR DESCRIPTION
Closes #827