### PR TITLE
Tweak dates, fix figure numbering, update changes document.

### DIFF
--- a/spec/acknowledgements.xml
+++ b/spec/acknowledgements.xml
@@ -12,7 +12,7 @@ Kirby (introductory example document; SMPTE time codes, descriptive metadata; EB
 and example images of style properties), Sean Hayes (advanced profile
 concepts, including applicative timing, HTML/CSS mapping proposal), Erik Hodge (timing),
 Thierry Michel (metadata), and Dave Singer (animation, scrolling).</p>
-<p>The editors also wish to acknowledge the support of the following current and past sponsors of his work
+<p>The editors also wish to acknowledge the support of the following current and past sponsors of their work
 on this specification: Cox Communications, Microsoft, Netflix, and Samsung Electronics.</p>
 <p>The Working Group dedicates this specification to our colleague David Kirby.</p>
 </inform-div1>

--- a/spec/acknowledgements.xml
+++ b/spec/acknowledgements.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <inform-div1 id="acknowledgments">
 <head>Acknowledgments</head>
-<p>The editor acknowledges the current and former members of the Timed Text Working
+<p>The editors acknowledge the current and former members of the Timed Text Working
 Group, the members of other W3C Working Groups, and industry experts
 in other forums who have contributed directly or indirectly to the
 process or content of this document as follows:</p>
 <p>&acknowledgements-current;</p>
-<p>The editor wishes to especially acknowledge the following contributions
+<p>The editors wish to especially acknowledge the following contributions
 by current and past members: Mike Dolan (SMPTE time codes, streaming; SMPTE liaison), David
 Kirby (introductory example document; SMPTE time codes, descriptive metadata; EBU/AAF liaison), Geoff Freed (styling
 and example images of style properties), Sean Hayes (advanced profile
 concepts, including applicative timing, HTML/CSS mapping proposal), Erik Hodge (timing),
 Thierry Michel (metadata), and Dave Singer (animation, scrolling).</p>
-<p>The editor also wishes to acknowledge the support of the following current and past sponsors of his work
+<p>The editors also wish to acknowledge the support of the following current and past sponsors of his work
 on this specification: Cox Communications, Microsoft, Netflix, and Samsung Electronics.</p>
 <p>The Working Group dedicates this specification to our colleague David Kirby.</p>
 </inform-div1>

--- a/spec/entitiescr.dtd
+++ b/spec/entitiescr.dtd
@@ -4,8 +4,8 @@
 <!ENTITY draft.year "2018">
 <!ENTITY draft.month "June">
 <!ENTITY draft.mm "06">
-<!ENTITY draft.day "25">
-<!ENTITY draft.dd "25">
+<!ENTITY draft.day "28">
+<!ENTITY draft.dd "28">
 
 <!ENTITY draft.date "&draft.year;&draft.mm;&draft.dd;">
 

--- a/spec/status.xml
+++ b/spec/status.xml
@@ -23,7 +23,7 @@ with a subject line starting with <code>[ttml2]</code>.  W3C publishes
 a Candidate Recommendation to indicate that the document is believed
 to be stable and to encourage implementation by the developer
 community. This Candidate Recommendation is expected to advance to
-Proposed Recommendation no earlier than 23 August 2018.</p>
+Proposed Recommendation no earlier than 9 August 2018.</p>
 
 <p>For this specification to exit CR, the following criteria must be
 met, as documented in the Working Group's <loc
@@ -70,10 +70,10 @@ feature.</p>
 
 <p>A cumulative summary of all changes applied to this version since
 the current (TTML1, 2nd Edition) Recommendation was published is
-available at <loc href="ttml2-changes.html">Changes from TTML1 (2nd
-Ed.) to TTML2 Working Draft (Latest Revision)</loc>.  An abbreviated
-list of changes affecting language syntax can be found at <specref
-ref="changes-from-ttml1-vocabulary"/>.</p>
+available at <loc href="ttml2-changes.html">Timed Text Markup Language
+2 (TTML2) Change Summary</loc>.  An abbreviated list of changes
+affecting language syntax can be found at
+<specref ref="changes-from-ttml1-vocabulary"/>.</p>
 
 <p>This document has been produced by the <loc
 href="https://www.w3.org/AudioVideo/TT/">Timed Text (TT) Working

--- a/spec/status.xml
+++ b/spec/status.xml
@@ -19,7 +19,10 @@ href="mailto:public-tt@w3.org">public-tt@w3.org</loc> (<loc
 href="mailto:public-tt-request@w3.org?subject=subscribe">subscribe</loc>,
 <loc
 href="http://lists.w3.org/Archives/Public/public-tt/">archives</loc>)
-with a subject line starting with <code>[ttml2]</code>.  W3C publishes
+with a subject line starting with <code>[ttml2]</code>. The deadline for
+comments is 26 July 2018.</p>
+
+<p>The W3C publishes
 a Candidate Recommendation to indicate that the document is believed
 to be stable and to encourage implementation by the developer
 community. This Candidate Recommendation is expected to advance to

--- a/spec/ttml2-changes.html
+++ b/spec/ttml2-changes.html
@@ -2,7 +2,7 @@
 <html lang="en-us">
 <head>
 <title>TTML 2 - List of changes</title>
-<style type="text/css">
+<style>
 div.exampleInner pre { margin-left: 1em;
                        margin-top: 0em; margin-bottom: 0em}
 div.exampleInner { background-color: #d5dee3;
@@ -345,7 +345,8 @@ div.exampleInner { background-color: #d5dee3;
 * Update schemas as required to adhere to specification revisions.
 
 </pre>
-</div>
+</div> <!-- exampleInner -->
+</div> <!-- div2 -->
 
 <div class="div2">
 <h3><a id="change-history-ttml1-rec-2e-to-ttml2-cr1"></a>1.1 Changes from
@@ -923,9 +924,9 @@ div.exampleInner { background-color: #d5dee3;
 
 * Update SMIL section number references to track SMIL3.
 </pre>
-</div>
-</div>
-</div>
+</div> <!-- exampleInner -->
+</div> <!-- div2 -->
+</div> <!-- div1 -->
 <script src="https://www.w3.org/scripts/TR/2016/fixup.js"></script>
 </body>
 </html>

--- a/spec/ttml2-changes.html
+++ b/spec/ttml2-changes.html
@@ -67,7 +67,9 @@ div.exampleInner { background-color: #d5dee3;
 
 <div class="div1">
 <h2><a id="change-history"></a>1 Change History (Non-Normative)</h2>
-<p>Changes are ordered from most recent to least recent.</p>
+<p>Change sections are ordered from most recent to least recent;
+within each section changes are divided into technical and editorial
+and further ordered by where they occur within the specification document.</p>
 
 <div class="div2">
 <h3><a id="change-history-ttml2-cr1-to-ttml2-cr2"></a>1.1 Changes from
@@ -90,7 +92,7 @@ div.exampleInner { background-color: #d5dee3;
 
 * In 5.2.4.{2,3}, instead of 'mostRestrictive' for the purpose of
   determining the profile combination method to be used when
-  combininig multiple top-level profiles, use the computed value of
+  combining multiple top-level profiles, use the computed value of
   the 'ttp:{content,processor}ProfileCombination' attributes,
   respectively.
 

--- a/spec/ttml2-changes.html
+++ b/spec/ttml2-changes.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en-us">
 <head>
+<meta charset="utf-8"/>
 <title>TTML 2 - List of changes</title>
 <style>
 div.exampleInner pre { margin-left: 1em;

--- a/spec/ttml2-changes.html
+++ b/spec/ttml2-changes.html
@@ -82,7 +82,8 @@ div.exampleInner { background-color: #d5dee3;
   profile fragment identifier, profile processing, timed element,
   validation processing, and validation processor.
 
-* In 3.2.1, insert new step (3) in order to invoke profile processing.
+* In 3.2.1, insert new step (3) under Generic Processor Conformance in
+  order to invoke profile processing.
 
 * In 3.3, add use of 'ttp:contentProfiles' and 'ttp:processorProfiles'
   to criteria for compliance claims on document instances.
@@ -254,6 +255,35 @@ div.exampleInner { background-color: #d5dee3;
 
 * In 13.3.7, allow '&lt;repeat-count&gt;' to take fractional values.
 
+* In Appendix E.1, add the following feature designators:
+  #animate-minimal, #animate-paced, #animate-spline, #base,
+  #base-general, #base-version-2, #condition-fn-media,
+  #condition-fn-parameter, #condition-fn-supports, #condition-primary,
+  #contentProfiles-combined, #display-version-2, #extent-auto,
+  #extent-auto-version-2, #extent-contain, #extent-cover,
+  #extent-full-version-2, #extent-length, #extent-length-version-2,
+  #extent-region-version-2, #extent-root-version-2, #image-png,
+  #length-root-container-relative, #length-version-2, #lineShear
+  #opacity-block, #opacity-inline, #opacity-region,
+  #opacity-version-2, #processorProfiles-combined,
+  #profile-full-version-2, #profile-nesting,
+  #region-implied-animation, #rubyAlign-minimal, #shear,
+  #textEmphasis-color, #textEmphasis-quoted-string,
+  #unicodeBidi-version-2, #visibility-image, #visibility-version-2,
+  and #xlink.
+
+* In Appendix E.1, remove the following feature designators:
+  #animate-calculation-mode, #animate-key-splines, #animate-key-times,
+  #condition-media, #extent-block, #fontFamily-p, #fontSize-p,
+  #fontStyle-p, #fontWeight-p, #inferProcessorProfile,
+  #region-inline-explicit, #region-inline-implicit,
+  #textEmphasis-no-color, #textEmphasis-no-quoted-string.
+
+* In Appendix J.1, add certain core attributes missing from
+  'isd:sequence', 'isd:isd', 'isd:css', and 'isd:region'.
+
+* In Appendix K, add normative reference [PNG].
+
 * Throughout, except for 'ttp:feature' and 'ttp:extension elements,
   add support for use of 'xml:base' attribute on all element types that
   did not previously support its use.
@@ -334,6 +364,27 @@ div.exampleInner { background-color: #d5dee3;
 * In 14, add prose (and note) clarifying that no presentation
   semantics apply to metadata.
 
+* In Appendix E, recommend (non-normatively) that implementations
+  parse known syntax even if some of that syntax is not supported
+  semantically speaking.
+
+* In Appendix E.1, clarify usage of phrase "all defined values."
+
+* In Appendix G, update profile documents to reflect additions and
+  removal of feature designators in E.1.
+
+* In Appendix G, add '@extends' attribute for features defined
+  as syntactic or semantic extensions in E.1.
+
+* In Appendix L, add non-normative references [Data Scheme],
+  [DVBSS], and [PG PNG].
+
+* In Appendix M, update requirement satisfaction information.
+
+* In Appendix N, update vocabulary derivation information.
+
+* In Appendix U, update new vocabulary information.
+
 * Throughout, update citations as needed in internal and external
   specification references, term references, and other forms of
   concept references.
@@ -342,6 +393,9 @@ div.exampleInner { background-color: #d5dee3;
   when term is referenced in text.
 
 * Throughout, minor improvements to language and correction of typos.
+
+* Throughout, make reference to [SRGB] when referring to RGB color
+  space.
 
 * Update schemas as required to adhere to specification revisions.
 

--- a/spec/ttml2-changes.html
+++ b/spec/ttml2-changes.html
@@ -77,10 +77,9 @@ div.exampleInner { background-color: #d5dee3;
 <span class="strong" id="cr2-technical-changes">Technical Changes</span>
 
 * In 2.2, add definition of terms: anonymous span, area, block area,
-  combined profile, content element, inline area, line area,
-  non-combined profile, profile fragment identifier, profile
-  processing, timed element, validation processing, and validation
-  processor.
+  combined profile, inline area, line area, non-combined profile,
+  profile fragment identifier, profile processing, timed element,
+  validation processing, and validation processor.
 
 * In 3.2.1, insert new step (3) in order to invoke profile processing.
 
@@ -144,12 +143,12 @@ div.exampleInner { background-color: #d5dee3;
 * In 9.1.4, specify optional use of deferred downloading of font
   resources.
 
-* In 10.1.1, add language handling the case of multiple 'initial'
-  elements applying to a single style property.
+* In 10.1.1, handle the case of multiple 'initial' elements applying
+  to a single style property.
 
 * In 10.2, add 'tts:lineShear' styling attribute (10.2.28).
 
-* In 10.2, add 'tts:shear' styling attribute.
+* In 10.2, add 'tts:shear' styling attribute (10.2.39).
 
 * In 10.2.17, remove 'p' from applies row of property definition table
   for 'tts:fontFamily'.
@@ -202,9 +201,61 @@ div.exampleInner { background-color: #d5dee3;
   content", "implied ruby base container", and "implied ruby text
   container".
 
+* In 10.2.37, clarify and constrain semantic applicability of
+  'tts:rubyPosition'.
+
+* In 10.2.38, redefine semantics of '&lt;length&gt;' component of
+  'tts:rubyReserve' to be based on the semantics of 'tts:fontSize'
+  that would apply to ruby text content.
+
+* In 10.2.38, clarify semantics of 'tts:rubyReserve' when ruby
+  text content is (also) present.
+
+* In 10.2.40, remove 'digits' expression from 'tts:textCombine';
+  specify (default) fallback value of 'none'.
+
+* In 10.2.46, clarify 'tts:textOutline' that the (default)
+  fallback value for blur radius is '0px'.
+
+* In 10.3.3, change semantics of 'outside' keyword for
+  '&lt;annotation-position&gt;' value syntax to apply 'before'
+  semantics for only first (or only) line, and 'after' semantics for
+  remaining lines.
+
+* In 10.3.33, constrain syntax for one-component and two-component
+  values of '&lt;position&gt;' to enhance compatibility with CSS.
+
+* In 10.3.35, clarify '&lt;shadow&gt;' that the (default)
+  fallback value for blur radius is '0px'.
+
+* In 10.3.36, remove 'digits' expression from '&lt;text-combine&gt;'.
+
+* In 10.3.40, change '&lt;text-shadow&gt;' value syntax to use
+  COMMA as delimiter instead of whitespace in a list of '&lt;shadow&gt;'
+  expressions.
+
+* In 12.2.4, remove deprecation of sequential time container in the
+  context of using discontinuous smpte mode timing.
+
+* In 12.3.1, remove optionality for the metric component of a
+  '&lt;time-expression&gt;', which restores TTML1 syntax in this
+  regard.
+
+* In 13.1.1, add clarifications and constraints pertaining to the
+  semantics of 'accumulate', 'additive', 'keySplines', 'keyTimes'
+  and 'repeatCount'.
+
+* In 13.3.2, require that '&lt;animation-value-list&gt;' contain
+  two or more '&lt;animation-value&gt;' components instead of one
+  or more such components.
+
+* In 13.3.3, add 'paced' keyword to '&lt;calculation-mode&gt;'.
+
+* In 13.3.7, allow '&lt;repeat-count&gt;' to take fractional values.
+
 * Throughout, except for 'ttp:feature' and 'ttp:extension elements,
   add support for use of 'xml:base' attribute on all element types that
-  did not previously allow its use.
+  did not previously support its use.
 
 <span class="strong" id="cr2-editorial-changes">Editorial Changes</span>
 
@@ -215,10 +266,10 @@ div.exampleInner { background-color: #d5dee3;
 
 * In 2.3, clarify use of '@' prefix when used with attribute names.
 
-* In 3.2, add introductory paragraph in prologue.
-
-* In 3.2, constrain 'TTML' to 'TTML2' as needed to correctly scope
+* In 3, constrain 'TTML' to 'TTML2' as needed to correctly scope
   specification text.
+
+* In 3.2, add introductory paragraph in prologue.
 
 * In 3.2.1, remove misleading language in notes pertaining to scope
   of mandatory and optional semantics.
@@ -235,6 +286,10 @@ div.exampleInner { background-color: #d5dee3;
 
 * In 8.1.5, add reference to [construct anonymous spans] procedure
   in prose describing use of anonymous span.
+
+* In 10, combine (non-audio) style attributes and audio style
+  attributes into same section, which has a side effect of renumbering
+  all 10.4.* subsections as 10.3.* subsections.
 
 * In 10, collapse language regarding applicability of a style property
   to span and, thus, to anonymous spans.
@@ -256,8 +311,27 @@ div.exampleInner { background-color: #d5dee3;
 * In 10.2.27, add to note that treatment of 'tts:lineHeight' is
   intended to be compatible with XSL-FO and CSS.
 
-* In 10.2.35, improve presentation of constraints that pertain
+* In 10.2.34, clarify explanation of example fragment.
+
+* In 10.2.35, reorganize presentation of constraints that pertain
   to the use of 'tts:ruby'.
+
+* In 10.2.35, add note that inline areas generated by ruby text
+  containers and ruby text content are descendants of the same
+  line area that contains its associated ruby base content.
+
+* In 10.2.36, clarify semantic applicability of 'tts:rubyAlign'.
+
+* In 10.3.34, remove obsolete keywords 'auto', 'between', 'around',
+  and rewrite syntax to use '&lt;annotation-position&gt;'.
+
+* In 11.3.2, Line Layout, divide content into two sub-sections,
+  placing the original content into 11.3.2.1 and adding a new
+  subsection 11.3.2.2 containing a non-normative description of line
+  stacking.
+
+* In 14, add prose (and note) clarifying that no presentation
+  semantics apply to metadata.
 
 * Throughout, update citations as needed in internal and external
   specification references, term references, and other forms of

--- a/spec/ttml2-changes.html
+++ b/spec/ttml2-changes.html
@@ -14,6 +14,7 @@ div.exampleInner { background-color: #d5dee3;
                    border-bottom-color: #d3d3d3;
                    padding: 4px; margin: 0em }
 .strong { font-weight: bold; }
+.emphasis { font-style: italic; }
 </style>
 <link rel="stylesheet" type="text/css" href="https://www.w3.org/StyleSheets/TR/2016/base.css"/>
 </head>
@@ -29,18 +30,31 @@ div.exampleInner { background-color: #d5dee3;
       </a>
       <ul class="toc">
         <li class="tocline">
-          <a class="tocxref" href="#change-history-ttml1-rec-2e-to-ttml2-cr1">
-            <span class="secno">1.1</span>Changes from TTML1 (2nd Ed.) to TTML2 First Candidate Recommendation (CR1)
-          </a>
+          <a class="tocxref" href="#change-history-ttml2-cr1-to-ttml2-cr2"><span class="secno">1.1</span>TTML2 CR1 to CR2</a>
           <ul class="toc">
             <li class="tocline">
-              <a class="tocxref" href="#technical-changes">
+              <a class="tocxref" href="#cr2-technical-changes">
                 <span class="secno">1.1.1</span>Technical Changes
               </a>
             </li>
             <li class="tocline">
-              <a class="tocxref" href="#editorial-changes">
+              <a class="tocxref" href="#cr2-editorial-changes">
                 <span class="secno">1.1.2</span>Editorial Changes
+              </a>
+            </li>
+          </ul>
+        </li>
+        <li class="tocline">
+          <a class="tocxref" href="#change-history-ttml1-rec-2e-to-ttml2-cr1"><span class="secno">1.2</span>TTML1 (2nd Ed.) to TTML2 CR1</a>
+          <ul class="toc">
+            <li class="tocline">
+              <a class="tocxref" href="#cr1-technical-changes">
+                <span class="secno">1.2.1</span>Technical Changes
+              </a>
+            </li>
+            <li class="tocline">
+              <a class="tocxref" href="#cr1-editorial-changes">
+                <span class="secno">1.2.2</span>Editorial Changes
               </a>
             </li>
           </ul>
@@ -55,11 +69,37 @@ div.exampleInner { background-color: #d5dee3;
 <p>Changes are ordered from most recent to least recent.</p>
 
 <div class="div2">
-  <h3><a id="change-history-ttml1-rec-2e-to-ttml2-cr1"></a>1.1 Changes from TTML1 (2nd Ed.) to
-    <a href="https://w3c.github.io/ttml2/index.html">TTML2 First Candidate Recommendation (CR1)</a></h3>
+<h3><a id="change-history-ttml2-cr1-to-ttml2-cr2"></a>1.1 Changes from
+    <a href="https://www.w3.org/TR/2018/CR-ttml2-20180313/">TTML2 First Candidate Recommendation (CR1)</a> to
+    <a href="https://w3c.github.io/ttml2/index.html">TTML2 Second Candidate Recommendation (CR2)</a></h3>
 <div class="exampleInner">
 <pre>
-<span class="strong" id="technical-changes">Technical Changes</span>
+<span class="strong" id="cr2-technical-changes">Technical Changes</span>
+
+* In 8.2, add 'xml:base' attribute to content attribute vocabulary, and,
+  in all element definitions except 'ttp:feature' and 'ttp:extension,
+  add support for use of 'xml:base' attribute.
+
+* In 10.2, add 'tts:lineShear' styling attribute.
+
+* In 10.2, add 'tts:shear' styling attribute.
+
+[<span class="emphasis">editing in progress</span>]
+
+<span class="strong" id="cr2-editorial-changes">Editorial Changes</span>
+
+[<span class="emphasis">editing in progress</span>]
+
+</pre>
+</div>
+
+<div class="div2">
+<h3><a id="change-history-ttml1-rec-2e-to-ttml2-cr1"></a>1.1 Changes from
+    <a href="https://www.w3.org/TR/2013/REC-ttml1-20130924/">TTML1 (2nd Ed.)</a> to
+    <a href="https://www.w3.org/TR/2018/CR-ttml2-20180313/">TTML2 First Candidate Recommendation (CR1)</a></h3>
+<div class="exampleInner">
+<pre>
+<span class="strong" id="cr1-technical-changes">Technical Changes</span>
 
 * In 3.2.1, add performance of document validation.
 
@@ -482,7 +522,7 @@ div.exampleInner { background-color: #d5dee3;
 * In Appendix H, upgrade material on time expression semantics to normative,
   (previously in Appendix N of TTML1).
 
-<span class="strong" id="editorial-changes">Editorial Changes</span>
+<span class="strong" id="cr1-editorial-changes">Editorial Changes</span>
 
 * In 1.1, update Figure 1 - System Model.
 

--- a/spec/ttml2-changes.html
+++ b/spec/ttml2-changes.html
@@ -76,19 +76,199 @@ div.exampleInner { background-color: #d5dee3;
 <pre>
 <span class="strong" id="cr2-technical-changes">Technical Changes</span>
 
-* In 8.2, add 'xml:base' attribute to content attribute vocabulary, and,
-  in all element definitions except 'ttp:feature' and 'ttp:extension,
-  add support for use of 'xml:base' attribute.
+* In 2.2, add definition of terms: anonymous span, area, block area,
+  combined profile, content element, inline area, line area,
+  non-combined profile, profile fragment identifier, profile
+  processing, timed element, validation processing, and validation
+  processor.
 
-* In 10.2, add 'tts:lineShear' styling attribute.
+* In 3.2.1, insert new step (3) in order to invoke profile processing.
+
+* In 3.3, add use of 'ttp:contentProfiles' and 'ttp:processorProfiles'
+  to criteria for compliance claims on document instances.
+
+* In 5.2.4.{2,3}, instead of 'mostRestrictive' for the purpose of
+  determining the profile combination method to be used when
+  combininig multiple top-level profiles, use the computed value of
+  the 'ttp:{content,processor}ProfileCombination' attributes,
+  respectively.
+
+* In 5.4.1, add 'xml:base' attribute to Core Attributes in
+  Table 5-5.
+
+* In 5.4.1, add 'tts:lineShear' and 'tts:shear' to Styling Attributes
+  in Table 5-5.
+
+* In 6.1.1, allow conformant processor to not support profile combination
+  (a combined profile) and/or profile nesting (a nesting profile).
+
+* In 6.1.2 and 6.1.4, constrain value syntax of 'xml:base' to &lt;uri&gt;
+  value syntax.
+
+* In 6.2.2, add 'ignore' token value for 'ttp:contentProfileCombination'
+  and make 'ignore' the fallback default value.
+
+* In 6.2.4, change the fallback default value of
+  'ttp:inferProcessorProfileSource' from 'combine' to 'first'.
+
+* In 6.2.9, add 'ignore' token value for 'ttp:processorProfileCombination'
+  and make 'ignore' the fallback default value.
+
+* In 6.2.11, allow validation abort processing to be overridden by
+  end-user or application.
+
+* In 8.1.1, remove 'condition' attribute from 'tt' element.
+
+* In 8.1.3, restore erroneously removed declaration of use of TTML
+  style attributes on 'body' element.
+
+* In 8.1.6, add prose describing use of anonymous spans that
+  is analogous to like prose found in 8.1.5 (defining 'p' element).
+
+* In 8.2, add 'xml:base' attribute to content attribute vocabulary,
+  and, in all element definitions that did not previously allow
+  'xml:base', add support for use of 'xml:base' attribute except for
+  'ttp:feature' and 'ttp:extension elements.
+
+* In 8.2.1, define exceptions to ignoring semantics on conditionally
+  excluded element.
+
+* In 8.2.7, define generic use of 'xml:base' attribute.
+
+* In 8.3, add content value syntax definitions for:
+  &lt;absolute-profile-designator&gt;, &lt;absolute-uri&gt;,
+  &lt;fragment-profile-designator&gt;, &lt;fragment-uri&gt;,
+  &lt;profile-designator&gt;, &lt;relative-profile-designator&gt;, and
+  &lt;relative-uri&gt;.
+
+* In 9.1.4, specify optional use of deferred downloading of font
+  resources.
+
+* In 10.1.1, add language handling the case of multiple 'initial'
+  elements applying to a single style property.
+
+* In 10.2, add 'tts:lineShear' styling attribute (10.2.28).
 
 * In 10.2, add 'tts:shear' styling attribute.
 
-[<span class="emphasis">editing in progress</span>]
+* In 10.2.17, remove 'p' from applies row of property definition table
+  for 'tts:fontFamily'.
+
+* In 10.2.17, add prose noting that 'tts:fontFamily' is used to resolve
+  the value of 'normal' for 'tts:lineHeight' on 'p' element.
+
+* In 10.2.18, remove 'p' from applies row of property definition table
+  for 'tts:fontKerning'.
+
+* In 10.2.20, remove 'p' from applies row of property definition table
+  for 'tts:fontShear'.
+
+* In 10.2.21, remove 'p' from applies row of property definition table
+  for 'tts:fontSize'.
+
+* In 10.2.21, add prose noting that 'tts:fontSize' is used to resolve
+  the value of 'normal' for 'tts:lineHeight' on 'p' element.
+
+* In 10.2.22, remove 'p' from applies row of property definition table
+  for 'tts:fontStyle'.
+
+* In 10.2.22, add prose noting that 'tts:fontStyle' is used to resolve
+  the value of 'normal' for 'tts:lineHeight' on 'p' element.
+
+* In 10.2.23, remove 'p' from applies row of property definition table
+  for 'tts:fontVariant'.
+
+* In 10.2.23, add prose noting that 'tts:fontVariant' is used to resolve
+  the value of 'normal' for 'tts:lineHeight' on 'p' element.
+
+* In 10.2.24, remove 'p' from applies row of property definition table
+  for 'tts:fontWeight'.
+
+* In 10.2.24, add prose noting that 'tts:fontWeight' is used to resolve
+  the value of 'normal' for 'tts:lineHeight' on 'p' element.
+
+* In 10.2.27, add use of 'tts:fontVariant' in step (4) of 'normal'
+  computations.
+
+* In 10.2.27, indicate that fallback of 125% for 'normal' value
+  of 'tts:lineHeight' is implementation dependent.
+
+* In 10.2.29, make 'tts:luminanceGain' non-inheritable, and add
+  prose qualifying applicability to pixels in a region.
+
+* In 10.2.35, change 'tts:ruby' to non-animatable.
+
+* In 10.2.35.1, add inline definitions of concepts "isolated ruby
+  content", "implied ruby base container", and "implied ruby text
+  container".
+
+* Throughout, except for 'ttp:feature' and 'ttp:extension elements,
+  add support for use of 'xml:base' attribute on all element types that
+  did not previously allow its use.
 
 <span class="strong" id="cr2-editorial-changes">Editorial Changes</span>
 
-[<span class="emphasis">editing in progress</span>]
+* In 2.2, revise definition of terms: content profile, effective
+  content profile, effective processor profile, glyph area, nesting
+  profile, non-nesting profile, processor profile, profile, validating
+  content processor,
+
+* In 2.3, clarify use of '@' prefix when used with attribute names.
+
+* In 3.2, add introductory paragraph in prologue.
+
+* In 3.2, constrain 'TTML' to 'TTML2' as needed to correctly scope
+  specification text.
+
+* In 3.2.1, remove misleading language in notes pertaining to scope
+  of mandatory and optional semantics.
+
+* In 3.3, add note clarifying scope of profile support for compliance
+  claims on processors.
+
+* In 5.2.1, restore use of 'ttp:profile' attribute in prose description
+  of techniques available for use when declaring a processor profile.
+
+* In 5.2.4, change name of 'profile' profile state object to
+  'profile instance' to avoid conflict with more general uses of the
+  term 'profile'.
+
+* In 8.1.5, add reference to [construct anonymous spans] procedure
+  in prose describing use of anonymous span.
+
+* In 10, collapse language regarding applicability of a style property
+  to span and, thus, to anonymous spans.
+
+* In 10.2.16, add note clarifying the distinction between 'auto' and
+  'auto auto' values of 'tts:extent'.
+
+* In 10.2.20, move prose defining shear calculations to 10.4.5.3
+  in order to share common definition with the three different
+  shear related style properties.
+
+* In 10.2.27, add note referring to new section 11.3.2.2
+  on line stacking with respect to the phrase "line height".
+
+* In 10.2.27, add note indicating that 'tts:lineHeight', in addition
+  to applying to the 'p' element, is used in resolving the
+  half-leading of inline areas produced by spans.
+
+* In 10.2.27, add to note that treatment of 'tts:lineHeight' is
+  intended to be compatible with XSL-FO and CSS.
+
+* In 10.2.35, improve presentation of constraints that pertain
+  to the use of 'tts:ruby'.
+
+* Throughout, update citations as needed in internal and external
+  specification references, term references, and other forms of
+  concept references.
+
+* Throughout, add or update explicit links to term definitions
+  when term is referenced in text.
+
+* Throughout, minor improvements to language and correction of typos.
+
+* Update schemas as required to adhere to specification revisions.
 
 </pre>
 </div>

--- a/spec/ttml2-errata.html
+++ b/spec/ttml2-errata.html
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html>
 <html lang="en-us">
   <head>
+    <meta charset="utf-8"/>
     <title>TTML2 - Errata</title>
     <link rel="stylesheet" type="text/css" href="http://www.w3.org/StyleSheets/TR/base.css"/>
   </head>

--- a/spec/ttml2-errata.html
+++ b/spec/ttml2-errata.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html
-  xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html lang="en-us">
   <head>
     <title>TTML2 - Errata</title>
     <link rel="stylesheet" type="text/css" href="http://www.w3.org/StyleSheets/TR/base.css"/>

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -2158,10 +2158,10 @@ should satisfy the web content accessibility guidelines specified by
 <div2 id="conformance-processor">
 <head>Processor Conformance</head>
 <p>This section specifies the conformance requirements for TTML2 processors in terms of
-<loc href="conformance-generic-processor">Generic Processor Conformance</loc>
+<loc href="#conformance-generic-processor">Generic Processor Conformance</loc>
 and two types of specialized processor conformance,
-<loc href="conformance-transformation-processor">Transformation Processor Conformance</loc> and
-<loc href="conformance-presentation-processor">Presentation Processor Conformance</loc>.</p>
+<loc href="#conformance-transformation-processor">Transformation Processor Conformance</loc> and
+<loc href="#conformance-presentation-processor">Presentation Processor Conformance</loc>.</p>
 <div3 id="conformance-generic-processor">
 <head>Generic Processor Conformance</head>
 <p>A TTML2 <loc href="#terms-content-processor">content processor</loc> conforms to this specification if the following
@@ -2303,22 +2303,22 @@ defined by <specref ref="vocabulary-profiling"/>, and, if a subset or
 superset profile is used or supported, then what features are excluded
 or included in the subset or superset profile.</p>
 <note role="clarification"><p>The definitions of
-<loc href="conformance-transformation-processor">Transformation Processor Conformance</loc> and
-<loc href="conformance-presentation-processor">Presentation Processor Conformance</loc> specified above require
+<loc href="#conformance-transformation-processor">Transformation Processor Conformance</loc> and
+<loc href="#conformance-presentation-processor">Presentation Processor Conformance</loc> specified above require
 that each of these types of processors support (at a minimum) two specific profiles, a type specific profile defined by <bibref ref="ttml1"/>
 and a type specific profile defined by this specification.</p>
 <p>Notwithstanding this requirement, it is possible to construct a
 TTML <loc href="#terms-content-processor">content processor</loc>
 that performs transformation or presentation processing functions and satisfies
-<loc href="conformance-transformation-processor">Generic Processor Conformance</loc> requirements but supports neither of
-the profiles required by <loc href="conformance-transformation-processor">Transformation Processor Conformance</loc> or
-<loc href="conformance-presentation-processor">Presentation Processor Conformance</loc>, and, instead,
+<loc href="#conformance-transformation-processor">Generic Processor Conformance</loc> requirements but supports neither of
+the profiles required by <loc href="#conformance-transformation-processor">Transformation Processor Conformance</loc> or
+<loc href="#conformance-presentation-processor">Presentation Processor Conformance</loc>, and, instead,
 supports only profile(s) defined outside the scope of this specification. In such a case, the processor may be claimed to be
-compliant with <loc href="conformance-transformation-processor">Generic Processor Conformance</loc>, and, further, be a
+compliant with <loc href="#conformance-transformation-processor">Generic Processor Conformance</loc>, and, further, be a
 TTML <loc href="#terms-transformation-processor">transformation processor</loc> or a
 TTML <loc href="#terms-presentation-processor">presentation processor</loc>,
-but may not claim compliance with <loc href="conformance-transformation-processor">Transformation Processor Conformance</loc> or
-<loc href="conformance-presentation-processor">Presentation Processor Conformance</loc>.</p></note>
+but may not claim compliance with <loc href="#conformance-transformation-processor">Transformation Processor Conformance</loc> or
+<loc href="#conformance-presentation-processor">Presentation Processor Conformance</loc>.</p></note>
 <p>A <loc href="#terms-document-instance">document instance</loc> for which a compliance claim is made must be associated with</p>
 <olist>
 <item><p>a non-null <loc href="#terms-effective-content-profile">effective content profile</loc>
@@ -20940,7 +20940,7 @@ transforming the <loc href="#style-attribute-fontVariant"><att>tts:fontVariant</
 feature if it supports the <code>#fontWeight</code> feature as defined by <bibref ref="ttml1"/>, &sect;D.1.37.</p>
 <note role="clarification"><p>Support for the <code>#fontWeight</code> feature is functionally equivalent to support for (1) the
 <loc href="#feature-fontWeight-bold"><code>#fontWeight-bold</code></loc> feature
-and (2) the <code>normal</code> value of <loc href="#weight-attribute-fontWeight"><att>tts:fontWeight</att></loc> attribute.</p>
+and (2) the <code>normal</code> value of <loc href="#style-attribute-fontWeight"><att>tts:fontWeight</att></loc> attribute.</p>
 </note>
 <p>It is an error for a content profile to require or permit use of the <code>#fontWeight</code> feature but prohibit use of the
 <loc href="#feature-fontWeight-bold"><code>#fontWeight-bold</code></loc> feature.</p>
@@ -21295,10 +21295,10 @@ feature if it supports the <code>#origin</code> feature as defined by <bibref re
 feature if it supports the <code>#overflow</code> feature as defined by <bibref ref="ttml1"/>, &sect;D.1.61.</p>
 <note role="clarification"><p>Support for the <code>#overflow</code> feature is functionally equivalent to support for (1) the
 <loc href="#feature-overflow-visible"><code>#overflow-visible</code></loc> feature
-and (2) the <code>hidden</code> value of <loc href="#weight-attribute-overflow"><att>tts:overflow</att></loc> attribute.</p>
+and (2) the <code>hidden</code> value of <loc href="#style-attribute-overflow"><att>tts:overflow</att></loc> attribute.</p>
 </note>
 <p>It is an error for a content profile to require or permit use of the <code>#overflow</code> feature but prohibit use of the
-<loc href="#feature-overflow-italic"><code>#overflow-visible</code></loc> feature.</p>
+<loc href="#feature-overflow-visible"><code>#overflow-visible</code></loc> feature.</p>
 </div3>
 <div3 id="feature-overflow-visible">
 <head>#overflow-visible</head>
@@ -21569,7 +21569,7 @@ feature if it (1) supports the <loc href="#feature-processorProfiles"><code>#pro
 feature if it implements presentation semantic support for the
 same vocabulary enumerated above.</p>
 <p>The <code>#processorProfiles-combine</code> feature is a syntactic and semantic extension of the
-<loc href="#feature-contenProfiles"><code>#processorProfiles</code></loc> feature.</p>
+<loc href="#feature-processorProfiles"><code>#processorProfiles</code></loc> feature.</p>
 <p>It is an error for a processor profile to require or permit use of the <code>#processorProfiles-combine</code> feature
 but prohibit use of the <loc href="#feature-processorProfiles"><code>#processorProfiles</code></loc> feature.</p>
 <note role="elaboration">
@@ -23462,7 +23462,7 @@ is optional (O), for a TTML <loc href="#terms-content-processor">content process
 <td css="text-align:center;">O</td>
 </tr>
 <tr>
-<td><loc href="#feature-profile-neswting"><code>#profile-nesting</code></loc></td>
+<td><loc href="#feature-profile-nesting"><code>#profile-nesting</code></loc></td>
 <td css="text-align:center;">2</td>
 <td css="text-align:center;">O</td>
 <td css="text-align:center;">O</td>

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -11182,7 +11182,7 @@ luminance, such as 10,000 cd∙m<sup>-2</sup>.</p>
 </tr>
 <tr>
 <td><emph>Animatable:</emph></td>
-<td>continuous, discrete</td>
+<td>discrete, continuous</td>
 </tr>
 <tr>
 <td><emph>Semantic basis:</emph></td>
@@ -14102,7 +14102,7 @@ the active duration of the element on which this attribute is specified.</p>
 </tr>
 <tr>
 <td><emph>Animatable:</emph></td>
-<td>continuous, discrete</td>
+<td>discrete, continuous</td>
 </tr>
 </tbody>
 </table>
@@ -14188,7 +14188,7 @@ the active duration of the element on which this attribute is specified.</p>
 </tr>
 <tr>
 <td><emph>Animatable:</emph></td>
-<td>continuous, discrete</td>
+<td>discrete, continuous</td>
 </tr>
 </tbody>
 </table>
@@ -14268,7 +14268,7 @@ determines speech pitch when  speech synthesis is enabled for the affected conte
 </tr>
 <tr>
 <td><emph>Animatable:</emph></td>
-<td>continuous, discrete</td>
+<td>discrete, continuous</td>
 </tr>
 </tbody>
 </table>
@@ -17824,7 +17824,7 @@ element.</p>
 by <bibref ref="smil3"/>, &sect;5.4.3,
 while taking into account any overriding semantics defined by this specification.
 In a deliberate divergence from <bibref ref="smil3"/>, &sect;5.4.3, the value of
-the <att>dur</att> attribute is permitted to be zero (0).</p>
+the <att>dur</att> attribute is permitted to be zero (<code>0s</code>).</p>
 <note role="elaboration">
 <p>In the context of the subset of <bibref ref="smil3"/> semantics supported by
 this specification, the active duration of an element that specifies both

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -11905,7 +11905,7 @@ styling.</p>
 <p>If a computed value of the property associated with this attribute is not supported,   
 then a <loc href="#terms-presentation-processor">presentation processor</loc> must use the value <code>none</code>.</p>
 <table id="ruby-semantics-mapping-table" role="common">
-<caption>Table 8-1 &ndash; Ruby Semantics Mapping</caption>
+<caption>Table 10-1 &ndash; Ruby Semantics Mapping</caption>
 <col css="width: 25%;"/>
 <col css="width: 25%;"/>
 <col css="width: 25%;"/>
@@ -12451,7 +12451,7 @@ by <bibref ref="cssruby"/>, &sect;4.1.</p>
 <p>If a computed value of the property associated with this attribute is not supported,
 then a <loc href="#terms-presentation-processor">presentation processor</loc> must use the value <code>before</code>.</p>
 <table id="rubyPosition-semantics-mapping-table" role="common">
-<caption>Table 8-2 &ndash; Absolute Ruby Position Semantics Mapping by Writing Mode</caption>
+<caption>Table 10-2 &ndash; Absolute Ruby Position Semantics Mapping by Writing Mode</caption>
 <col css="width: 20%;"/>
 <col css="width: 20%;"/>
 <col css="width: 20%;"/>
@@ -25667,7 +25667,7 @@ indicates the extent to which they are satisfied by this specification, where
 a requirement is partially satisfied, and <emph>N</emph> denotes a
 requirement is not satisfied.</p>
 <table id="requirements-table" role="common">
-<caption>Table L-1 &ndash; Requirement Satisfaction</caption>
+<caption>Table M-1 &ndash; Requirement Satisfaction</caption>
 <col css="width: 10%;"/>
 <col css="width: 40%;"/>
 <col css="width: 10%;"/>
@@ -26178,7 +26178,7 @@ corresponding TTML element; in contrast, the details column includes
 that is not specified for use with the <el>xhtml:div</el> model
 element.</p>
 <table id="element-vocab-derivation-table" role="common">
-<caption>Table M-1 &ndash; Elements</caption>
+<caption>Table N-1 &ndash; Elements</caption>
 <col css="width: 20%;"/>
 <col css="width: 17%;"/>
 <col css="width: 13%; text-align: center;"/>
@@ -26561,7 +26561,7 @@ above.</p>
 <p>Style attribute derivations are listed separately below.</p>
 <p></p>
 <table id="attribute-vocab-derivation-table" role="common">
-<caption>Table M-2 &ndash; Attributes</caption>
+<caption>Table N-2 &ndash; Attributes</caption>
 <col css="width: 20%;"/>
 <col css="width: 17%;"/>
 <col css="width: 13%; text-align: center;"/>
@@ -28357,7 +28357,7 @@ ref="qaf-sg"/>.</p>
 <div2>
 <head>Requirements</head>
 <table id="qa-framework-requirements-table" role="common">
-<caption>Table N-1 &ndash; QA Framework Requirements Checklist</caption>
+<caption>Table O-1 &ndash; QA Framework Requirements Checklist</caption>
 <col css="width: 76%;"/>
 <col css="width: 6%; text-align: center;"/>
 <col css="width: 6%; text-align: center;"/>
@@ -28469,7 +28469,7 @@ clause</xspecref></td>
 <div2>
 <head>Guidelines</head>
 <table id="qa-framework-guidelines-table" role="common">
-<caption>Table N-2 &ndash; QA Framework Guidelines Checklist</caption>
+<caption>Table O-2 &ndash; QA Framework Guidelines Checklist</caption>
 <col css="width: 76%;"/>
 <col css="width: 6%; text-align: center;"/>
 <col css="width: 6%; text-align: center;"/>

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -20290,7 +20290,7 @@ or <loc href="#terms-nesting-profile">nesting profiles</loc>.</p>
 feature if it implements presentation semantic support for the
 same vocabulary enumerated above.</p>
 <p>The <code>#contentProfiles-combine</code> feature is a syntactic and semantic extension of the
-<loc href="#feature-contenProfiles"><code>#contentProfiles</code></loc> feature.</p>
+<loc href="#feature-contentProfiles"><code>#contentProfiles</code></loc> feature.</p>
 <p>It is an error for a content profile to require or permit use of the <code>#contentProfiles-combine</code> feature
 but prohibit use of the <loc href="#feature-contentProfiles"><code>#contentProfiles</code></loc> feature.</p>
 <note role="elaboration">

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -28779,7 +28779,7 @@ fragments.</p>
 <p>An example of such a fragmentation of a <loc href="#terms-document-instance">document instance</loc> is
 shown in <specref ref="fragment-streaming-graphic"/>.</p>
 <table id="fragment-streaming-graphic" role="example-images">
-<caption>Figure 3 &ndash; Fragment Streaming</caption>
+<caption>Figure 2 &ndash; Fragment Streaming</caption>
 <col/>
 <tbody>
 <tr>
@@ -28820,13 +28820,13 @@ guaranteed to result in an identical document instance.</p>
 <p>This technique is used for example in <bibref ref="isobmff"/> and in <bibref ref="ebuttlive"/>.</p>
 </note>
 <p>An example of such a fragmentation of a <loc href="#terms-document-instance">document instance</loc> is
-shown in <specref ref="fragment-streaming-graphic-2"/>.</p>
-<table id="fragment-streaming-graphic-2" role="example-images">
-<caption>Figure 4 &ndash; Temporal fragmentation</caption>
+shown in <specref ref="temporal-fragmentation-graphic"/>.</p>
+<table id="temporal-fragmentation-graphic" role="example-images">
+<caption>Figure 3 &ndash; Temporal Fragmentation</caption>
 <col/>
 <tbody>
 <tr>
-<td><graphic id="graphic-temporal-fragmentation" source="images/temporal-fragmentation.png" alt="Temporal Fragment Streaming"/></td>
+<td><graphic id="graphic-temporal-fragmentation" source="images/temporal-fragmentation.png" alt="Temporal Fragmentation"/></td>
 </tr>
 </tbody>
 </table>
@@ -28955,7 +28955,7 @@ whilst not introducing unexpected line breaks.</p>
 <head>Changes to Vocabulary from TTML1</head>
 <p>This section provides a high level summary of vocabulary changes between Timed Text Markup Language (TTML) Version 1 (TTML1)
 and Version 2 (TTML2). It is not the intent of this summary to be exhaustive. For more details about changes,
-see <loc href="ttml2-changes.html#change-history-ttml1-rec-2e-to-ttml2-cr1">Changes from TTML1 (2nd Ed.) to TTML2 First Candidate Recommendation (CR1)</loc>.</p>
+see <loc href="ttml2-changes.html">Timed Text Markup Language 2 (TTML2) Change Summary</loc>.</p>
 <div2>
 <head>New Element Vocabulary</head>
 <p>New element vocabulary was added in the following sections of this specification as further described below:</p>


### PR DESCRIPTION
The _new_ dates are based on starting CfC tomorrow (06/13) and publishing CR2 on 06/28. The no earlier than date for PR comes from https://w3c.github.io/spec-releases/milestones/?cr=2018-06-28.