### PR TITLE
Remove @style from initial in schemas (#878).

### DIFF
--- a/spec/rnc/ttml2-layout.rnc
+++ b/spec/rnc/ttml2-layout.rnc
@@ -38,9 +38,7 @@ TTAF.layout.region.attlist &=
   TTAF.Core.Condition.attrib.class,
   TTAF.TimedContainer.attrib.class,
   TTAF.AnimationBinding.attrib.class,
-  TTAF.style.attrib,
-  (TTAF.Styling.attrib.class |
-   TTAF.Styling.ForeignExtension.attrib+ )
+  TTAF.Styled.attrib.class
 
 TTAF.layout.region.content.extra = empty
 TTAF.layout.region.content =

--- a/spec/rnc/ttml2-styling-attribs.rnc
+++ b/spec/rnc/ttml2-styling-attribs.rnc
@@ -111,11 +111,6 @@ TTAF.writingMode.attrib
 TTAF.zIndex.attrib
   = attribute tts:zIndex { TTAF.ZIndex.datatype }?
 
-# Extension Style Attributes
-
-TTAF.Styling.ForeignExtension.attrib =
-  attribute * - ( tt:* | tts:* | xml:* | local:* ) { text }
-
 # Styling Attribute Class
 
 TTAF.Styling.attrib.class &=

--- a/spec/rnc/ttml2-styling.rnc
+++ b/spec/rnc/ttml2-styling.rnc
@@ -33,9 +33,7 @@ TTAF.styling.style =
 TTAF.styling.style.attlist =
   TTAF.Core.attrib.class,
   TTAF.Core.Condition.attrib.class,
-  TTAF.style.attrib,
-  (TTAF.Styling.attrib.class |
-   TTAF.Styling.ForeignExtension.attrib+ )
+  TTAF.Styled.attrib.class
 
 TTAF.styling.style.content.extra = empty
 TTAF.styling.style.content =
@@ -52,9 +50,7 @@ TTAF.styling.initial =
 TTAF.styling.initial.attlist =
   TTAF.Core.attrib.class,
   TTAF.Core.Condition.attrib.class,
-  TTAF.style.attrib,
-  (TTAF.Styling.attrib.class |
-   TTAF.Styling.ForeignExtension.attrib+ )
+  TTAF.Styled.NoBinding.attrib.class
 
 TTAF.styling.initial.content.extra = empty
 TTAF.styling.initial.content =

--- a/spec/xsd/ttml2-styling.xsd
+++ b/spec/xsd/ttml2-styling.xsd
@@ -29,7 +29,7 @@
   <xs:attributeGroup name="initial.attlist">
     <xs:attributeGroup ref="tt:Core.attrib.class"/>
     <xs:attributeGroup ref="tt:Core.Condition.attrib.class"/>
-    <xs:attributeGroup ref="tt:Styled.attrib.class"/>
+    <xs:attributeGroup ref="tt:Styled.NoBinding.attrib.class"/>
   </xs:attributeGroup>
   <xs:complexType name="styling.eltype">
     <xs:sequence>


### PR DESCRIPTION
Closes #878.

This is an editorial change to make the schemas consistent with current specification text with respect to `initial` not using `@style`.