### PR TITLE
Fix link warning for DVBSS bibliographic entry (#935).

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -25772,8 +25772,8 @@ European Broadcasting Union (EBU), March 2015.
 <titleref href="https://tech.ebu.ch/publications/tech3370">EBU-TT Part 3 Live Subtitling Applications, Version 1.0</titleref>, European Broadcasting Union (EBU), May 2017.
 (See <xspecref href="https://tech.ebu.ch/publications/tech3370">https://tech.ebu.ch/publications/tech3370</xspecref>.)</bibl>
 <bibl id="DVBSS" key="DVBSS">ETSI EN 300 743,
-<titleref href="http://www.etsi.org/deliver/etsi_en/300700_300799/300743/01.05.01_60/en_300743v010501p.pdf">Digital Video Broadcasting (DVB); Subtitling systems, Version 1.5.1</titleref>, ETSI, January 2014.
-(See <xspecref href="http://www.etsi.org/deliver/etsi_en/300700_300799/300743/01.05.01_60/en_300743v010501p.pdf">http://www.etsi.org/deliver/etsi_en/300700_300799/300743/01.05.01_60/en_300743v010501p.pdf (PDF)</xspecref>.)</bibl>
+<titleref href="https://www.etsi.org/deliver/etsi_en/300700_300799/300743/01.05.01_60/en_300743v010501p.pdf">Digital Video Broadcasting (DVB); Subtitling systems, Version 1.5.1</titleref>, ETSI, January 2014.
+(See <xspecref href="https://www.etsi.org/deliver/etsi_en/300700_300799/300743/01.05.01_60/en_300743v010501p.pdf">https://www.etsi.org/deliver/etsi_en/300700_300799/300743/01.05.01_60/en_300743v010501p.pdf</xspecref>.)</bibl>
 <bibl id="html52" key="HTML 5.2">Steve Faulkner, Arron Eicholz, Travis Leithead, Alex Danilo, and Sangwhan Moon, Eds.,
 <titleref href="http://www.w3.org/TR/2017/REC-html52-20171214/">HTML 5.2</titleref>,
 W3C Recommendation, 14 December 2017. (See


### PR DESCRIPTION
Closes #935.