### PR TITLE
Widen data type for tta:{gain,pan} (#955).

### DIFF
--- a/spec/rnc/ttml2-datatypes.rnc
+++ b/spec/rnc/ttml2-datatypes.rnc
@@ -170,7 +170,7 @@ TTAF.FrameRateMultiplier.datatype =
   xsd:string { pattern = "\p{Nd}+\s+\p{Nd}+" }
 
 TTAF.Gain.datatype =
-  xsd:decimal 
+  string
   
 TTAF.Image.datatype =
   TTAF.URI.datatype
@@ -261,7 +261,7 @@ TTAF.Padding.datatype =
   string
 
 TTAF.Pan.datatype =
-  xsd:decimal
+  string
   
 TTAF.PermitFeatureNarrowingOrWidening.datatype =
   TTAF.Boolean.datatype

--- a/spec/xsd/ttml2-datatypes.xsd
+++ b/spec/xsd/ttml2-datatypes.xsd
@@ -765,10 +765,10 @@
     <xs:restriction base="xs:string"/>
   </xs:simpleType>
   <xs:simpleType name="gain">
-    <xs:restriction base="xs:decimal"/>   
+    <xs:restriction base="xs:string"/>   
   </xs:simpleType>
   <xs:simpleType name="pan">
-    <xs:restriction base="xs:decimal"/>
+    <xs:restriction base="xs:string"/>
   </xs:simpleType>
   <xs:simpleType name="pitch">
     <xs:restriction base="xs:string"/>


### PR DESCRIPTION
Closes #955.