### PR TITLE
Add missing 'prohibited' value to 'tts:validation' in schemas (#977).

### DIFF
--- a/spec/rnc/ttml2-datatypes.rnc
+++ b/spec/rnc/ttml2-datatypes.rnc
@@ -477,7 +477,8 @@ TTAF.UnicodeRange.datatype =
 
 TTAF.Validation.datatype =
   "required" |
-  "optional"
+  "optional" |
+  "prohibited"
 
 TTAF.ValidationAction.datatype =
   "abort" |

--- a/spec/xsd/ttml2-datatypes.xsd
+++ b/spec/xsd/ttml2-datatypes.xsd
@@ -724,6 +724,7 @@
     <xs:restriction base="xs:token">
       <xs:enumeration value="required"/>
       <xs:enumeration value="optional"/>
+      <xs:enumeration value="prohibited"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="validationAction">


### PR DESCRIPTION
Closes #977.