### PR TITLE
Update #audio-{description,speech} per WG resolution (#990).

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -19986,13 +19986,13 @@ same vocabulary enumerated above.</p>
 <p>A TTML processor supports the <code>#audio-description</code> feature if it
 supports the following features:</p>
 <ulist>
-<item><p><loc href="#feature-embedded-audio"><code>#embedded-audio</code></loc></p></item>
+<item><p><loc href="#feature-audio"><code>#audio</code></loc></p></item>
 <item><p><loc href="#feature-gain"><code>#gain</code></loc></p></item>
 <item><p><loc href="#feature-pan"><code>#pan</code></loc></p></item>
 </ulist>
 <p>It is an error for a content profile to require or permit use of the <code>#audio-description</code> feature but prohibit use of any of the following
 features:
-<loc href="#feature-embedded-audio"><code>#embedded-audio</code></loc>,
+<loc href="#feature-audio"><code>#audio</code></loc>,
 <loc href="#feature-gain"><code>#gain</code></loc>, or
 <loc href="#feature-pan"><code>#pan</code></loc>.</p>
 </div3>
@@ -20001,18 +20001,12 @@ features:
 <p>A TTML processor supports the <code>#audio-speech</code> feature if it
 supports the following features:</p>
 <ulist>
-<item><p><loc href="#feature-embedded-audio"><code>#embedded-audio</code></loc></p></item>
-<item><p><loc href="#feature-gain"><code>#gain</code></loc></p></item>
-<item><p><loc href="#feature-pan"><code>#pan</code></loc></p></item>
 <item><p><loc href="#feature-pitch"><code>#pitch</code></loc></p></item>
 <item><p><loc href="#feature-speak"><code>#speak</code></loc></p></item>
 <item><p><loc href="#feature-speech"><code>#speech</code></loc></p></item>
 </ulist>
 <p>It is an error for a content profile to require or permit use of the <code>#audio-speech</code> feature but prohibit use of any of the following
 features:
-<loc href="#feature-embedded-audio"><code>#embedded-audio</code></loc>,
-<loc href="#feature-gain"><code>#gain</code></loc>,
-<loc href="#feature-pan"><code>#pan</code></loc>,
 <loc href="#feature-pitch"><code>#pitch</code></loc>,
 <loc href="#feature-speak"><code>#speak</code></loc>, or
 <loc href="#feature-speech"><code>#speech</code></loc>.</p>


### PR DESCRIPTION
Closes #990.

This is a substantive change, but is covered under the at-risk process to occur without triggering a new CR. These changes are being made to permit audio description and audio speech functional constellations to be designated as identifiable features (1) without resorting to the functionality of embedded (versus externally referenced) audio and (2) without requiring the admixture of speech and non-speech audio functionality.