### PR TITLE
Prevent font element from overriding generic font family (#1042).

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -7435,7 +7435,7 @@ the specified attribute value(s) are to be used instead of the font characterist
 <p>If any of the <att>family</att>, <att>range</att>, <att>style</att>, or <att>weight</att> attributes are not specified, then their values
 must be considered to be equal to the value(s) of the same named font characteristics encoded in the <loc href="#terms-font-resource">font resource</loc>.</p>
 <p>If the computed value of the <code>family</code> attribute (whether explicitly specified or not) matches a
-<loc href="#style-value-generic-family-name">&lt;generic-family-name&gt;</loc> using case-insensitive comparison,
+<loc href="#style-value-generic-family-name">&lt;generic-family-name&gt;</loc> (by case-sensitive comparison),
 then it is considered an error, and the referenced font resource must be ignored for the purpose of presentation processing.</p>
 <note role="elaboration">
 <p>The effect of the previous paragraph is that a content author may not override a built-in font resource that corresponds to a generic font family.</p>
@@ -14982,9 +14982,9 @@ where <emph>content</emph> is the unquoted content of the quoted string, i.e., t
 <item><p>a &lt;family-name&gt; that takes the form of an <code>unquoted-string</code> that contains an <code>identifier</code> that
 starts with two <code>-</code> HYPHEN-MINUS (U+002D) characters must be considered to be invalid;</p></item>
 <item><p>a &lt;family-name&gt; that takes the form of an <code>unquoted-string</code> that contains a single <code>identifier</code> that
-matches (by case sensitive comparison) a &lt;generic-family-name&gt; must be interpreted as that &lt;generic-family-name&gt;;</p></item>
+matches (by case-sensitive comparison) a &lt;generic-family-name&gt; must be interpreted as that &lt;generic-family-name&gt;;</p></item>
 <item><p>a &lt;family-name&gt; that takes the form of a <code>quoted-string</code> whose content (unquoted value)
-matches (by case sensitive comparison) a &lt;generic-family-name&gt; must not be interpreted as that &lt;generic-family-name&gt;, but as
+matches (by case-sensitive comparison) a &lt;generic-family-name&gt; must not be interpreted as that &lt;generic-family-name&gt;, but as
 the actual name of a non-generic font family.</p></item>
 <item><p>The syntactic element <emph><code>char</code></emph> is to be interpreted according
 to the <code>Char</code> production defined by <bibref ref="xml10"/>, &sect;2.2.</p></item>

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -7434,6 +7434,12 @@ if the specified attribute value(s) differ from the value(s) of these font chara
 the specified attribute value(s) are to be used instead of the font characteristics encoded in the <loc href="#terms-font-resource">font resource</loc>.</p>
 <p>If any of the <att>family</att>, <att>range</att>, <att>style</att>, or <att>weight</att> attributes are not specified, then their values
 must be considered to be equal to the value(s) of the same named font characteristics encoded in the <loc href="#terms-font-resource">font resource</loc>.</p>
+<p>If the computed value of the <code>family</code> attribute (whether explicitly specified or not) matches a
+<loc href="#style-value-generic-family-name">&lt;generic-family-name&gt;</loc> using case-insensitive comparison,
+then it is considered an error, and the referenced font resource must be ignored for the purpose of presentation processing.</p>
+<note role="elaboration">
+<p>The effect of the previous paragraph is that a content author may not override a built-in font resource that corresponds to a generic font family.</p>
+</note>
 <note role="guideline">
 <p>Authors are advised to use subset fonts wherever possible. A subset font is a syntactically valid <loc href="#terms-font-resource">font resource</loc> that
 removes unreferenced glyphs and unreferenced glyph metrics. In general, a subset font is tied to a specific document, since it may have been generated


### PR DESCRIPTION
Closes #1042.