### PR TITLE
Specify fixed, implied semantics for xlink:type and xlink:actuate (#1039).

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -6307,6 +6307,15 @@ value evaluates to <code>false</code>:</p>
 <p>The <att>xlink:href</att> attribute is used as defined by <bibref ref="xlink11"/>.</p>
 <p>The <att>xlink:href</att> attribute may be used with any <loc href="#content-vocabulary-span"><el>span</el></loc> or
 <loc href="#embedded-content-vocabulary-image"><el>image</el></loc> element.</p>
+<p>For the purpose of implementing <att>xlink:href</att> semantics, the semantics of
+<loc href="https://www.w3.org/TR/2010/REC-xlink11-20100506/#link-types"><code>xlink:type</code></loc>
+are fixed to those associated with the <code>simple</code> value and the semantics of
+<loc href="https://www.w3.org/TR/2010/REC-xlink11-20100506/#actuate-att"><code>xlink:actuate</code></loc>
+are fixed to those associated with the <code>onRequest</code> value as defined by <bibref ref="xlink11"/>.</p>
+<note role="clarification">
+<p>Neither <code>xlink:type</code> nor <code>xlink:actuate</code> attribute is defined for direct use in
+a <loc href="#terms-document-instance">document instance</loc>.</p>
+</note>
 </div3>
 <div3 id="content-attribute-xlink-role">
 <head>xlink:role</head>


### PR DESCRIPTION
Closes #1039.