### PR TITLE
Remove superfluous colon ':' from namespace prefixes (#1037).

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -2605,32 +2605,32 @@ normative URI that denotes each namespace.</p>
 </tr>
 <tr>
 <td>TT</td>
-<td><code>tt:</code></td>
+<td><code>tt</code></td>
 <td><code>http://www.w3.org/ns/ttml</code></td>
 </tr>
 <tr>
 <td>TT Parameter</td>
-<td><code>ttp:</code></td>
+<td><code>ttp</code></td>
 <td><code>http://www.w3.org/ns/ttml#parameter</code></td>
 </tr>
 <tr>
 <td>TT Style</td>
-<td><code>tts:</code></td>
+<td><code>tts</code></td>
 <td><code>http://www.w3.org/ns/ttml#styling</code></td>
 </tr>
 <tr>
 <td>TT Audio Style</td>
-<td><code>tta:</code></td>
+<td><code>tta</code></td>
 <td><code>http://www.w3.org/ns/ttml#audio</code></td>
 </tr>
 <tr>
 <td>TT Metadata</td>
-<td><code>ttm:</code></td>
+<td><code>ttm</code></td>
 <td><code>http://www.w3.org/ns/ttml#metadata</code></td>
 </tr>
 <tr>
 <td>TT Intermediate Synchronic Document</td>
-<td><code>isd:</code></td>
+<td><code>isd</code></td>
 <td><code>http://www.w3.org/ns/ttml#isd</code></td>
 </tr>
 <tr>


### PR DESCRIPTION
Closes #1037.