### PR TITLE
Clarify relative profile designator does not use xml:base (#1033).

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -6921,8 +6921,13 @@ the TT Profile Namespace, which serves as the base URI with which relative profi
 </tr>
 </tbody>
 </table>
+<note role="clarification">
+<p>When absolutizing a &lt;relative-profile-designator&gt;,
+<loc href="#content-attribute-xml-base">xml:base</loc> processing does not apply (because the TT Profile Namespace
+always serves as the base URI).</p>
+</note>
 <note role="example">
-<p>For example, if a relative profile designator is expressed as
+<p>For example, if a &lt;relative-profile-designator&gt; is expressed as
 <code>ttml2-presentation</code>, then the absolutized profile designator
 would be
 <code>http://www.w3.org/ns/ttml/profile/ttml2-presentation</code>.</p>


### PR DESCRIPTION
Closes #1033.