### PR TITLE
Clarify non-applicability of character related styles in ruby container context (#1043).

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -12396,15 +12396,16 @@ likewise, an explicitly specified <loc href="#content-vocabulary-span"><el>span<
 <loc href="#style-attribute-ruby"><att>tts:ruby</att></loc> is <code>textContainer</code> is referred to as
 an <termdef id="defs-explicit-ruby-text-container" term=""><term>explicit ruby text container</term></termdef>.</p>
 <note role="clarification">
-<p>Style properties which apply to text children or <loc href="#terms-anonymous-span">anonymous span</loc>
+<p>Style properties which might apply to <loc href="#terms-anonymous-span">anonymous span</loc>
 children of a <el>span</el> element that functions as a <termref def="defs-ruby-container">ruby container</termref>,
 <termref def="defs-ruby-base-container">ruby base container</termref>, or <termref def="defs-ruby-text-container">ruby text container</termref>
-have no semantic affect during presentation processing since no significant text node appears as a child (or as a child of an
-<loc href="#terms-anonymous-span">anonymous span</loc> child) of such a <el>span</el> element. For example,
+have no semantic affect during presentation processing since no significant text node appears as a child of an
+<loc href="#terms-anonymous-span">anonymous span</loc> child of such a <el>span</el> element. For example,
 if a <loc href="#style-attribute-fontStyle"><att>tts:fontStyle</att></loc> attribute is specified on such a <el>span</el> element,
-then it has no significant text node in scope to which it may be applied. Note, however, that a value specified for
+then it has no significant text node in scope to which it may be applied; however, a value specified for
 <loc href="#style-attribute-fontStyle"><att>tts:fontStyle</att></loc> on such a <el>span</el> element still applies for the purpose of
-<loc href="#semantics-style-inheritance">style inheritance</loc>.</p>
+<loc href="#semantics-style-inheritance">style inheritance</loc> by other (non-anonymous) <el>span</el> element children of such a
+<el>span</el> element.</p>
 </note>
 </div4>
 </div3>

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -12094,7 +12094,10 @@ if the computed value of <att>tts:ruby</att> of a <loc href="#content-vocabulary
 <item><p>the computed value of <att>tts:ruby</att> of each of its child elements is not <code>none</code>;</p></item>
 <item><p>the computed value of <att>tts:ruby</att> of its first child element is <code>baseContainer</code>
 or <code>base</code>;</p></item>
-<item><p>each of its text node children contain only <loc href="#style-value-lwsp">&lt;lwsp&gt;</loc>;</p></item>
+<item><p>each of its text node children and <loc href="#terms-anonymous-span">anonymous span</loc> children
+contain only <loc href="#style-value-lwsp">&lt;lwsp&gt;</loc>, which must be ignored for the purpose of
+presentation processing regardless of whether the computed value of the <loc href="#content-attribute-xml-space"><att>xml:space</att></loc> attribute
+is <code>preserve</code> or not;</p></item>
 </ulist>
 <p>When using <att>tts:ruby</att>, the following nesting constraints apply to a <termref def="defs-ruby-base-container">ruby base container</termref>, that is,
 if the computed value of <att>tts:ruby</att> of a <loc href="#content-vocabulary-span"><el>span</el></loc> element is <code>baseContainer</code>, then:</p>
@@ -12103,7 +12106,10 @@ if the computed value of <att>tts:ruby</att> of a <loc href="#content-vocabulary
 <item><p>the computed value of <att>tts:ruby</att> of each of its child elements is not <code>none</code>;</p></item>
 <item><p>the computed value of <att>tts:ruby</att> of its first child element is <code>base</code>;</p></item>
 <item><p>its preceding sibling is <code>null</code> (i.e., no preceding sibling);</p></item>
-<item><p>each of its text node children contain only <loc href="#style-value-lwsp">&lt;lwsp&gt;</loc>;</p></item>
+<item><p>each of its text node children and <loc href="#terms-anonymous-span">anonymous span</loc> children
+contain only <loc href="#style-value-lwsp">&lt;lwsp&gt;</loc>, which must be ignored for the purpose of
+presentation processing regardless of whether the computed value of the <loc href="#content-attribute-xml-space"><att>xml:space</att></loc> attribute
+is <code>preserve</code> or not;</p></item>
 </ulist>
 <p>When using <att>tts:ruby</att>, the following nesting constraints apply to a <termref def="defs-ruby-text-container">ruby text container</termref>, that is,
 if the computed value of <att>tts:ruby</att> of a <loc href="#content-vocabulary-span"><el>span</el></loc> element is <code>textContainer</code>, then:</p>
@@ -12114,7 +12120,10 @@ if the computed value of <att>tts:ruby</att> of a <loc href="#content-vocabulary
 <item><p>the computed value of <att>tts:ruby</att> of its preceding sibling is <code>baseContainer</code> or
 <code>textContainer</code>;</p></item>
 <item><p>the computed value of <att>tts:ruby</att> of no more than one of its siblings is <code>textContainer</code>;</p></item>
-<item><p>each of its text node children contain only <loc href="#style-value-lwsp">&lt;lwsp&gt;</loc>;</p></item>
+<item><p>each of its text node children and <loc href="#terms-anonymous-span">anonymous span</loc> children
+contain only <loc href="#style-value-lwsp">&lt;lwsp&gt;</loc>, which must be ignored for the purpose of
+presentation processing regardless of whether the computed value of the <loc href="#content-attribute-xml-space"><att>xml:space</att></loc> attribute
+is <code>preserve</code> or not;</p></item>
 </ulist>
 <p>When using <att>tts:ruby</att>, the following nesting constraints apply to <termref def="defs-ruby-base-content">ruby base content</termref>, that is,
 if the computed value of <att>tts:ruby</att> of a <loc href="#content-vocabulary-span"><el>span</el></loc> element is <code>base</code>, then:</p>
@@ -12386,6 +12395,17 @@ an <termdef id="defs-explicit-ruby-base-container" term=""><term>explicit ruby b
 likewise, an explicitly specified <loc href="#content-vocabulary-span"><el>span</el></loc> element for which the computed value of
 <loc href="#style-attribute-ruby"><att>tts:ruby</att></loc> is <code>textContainer</code> is referred to as
 an <termdef id="defs-explicit-ruby-text-container" term=""><term>explicit ruby text container</term></termdef>.</p>
+<note role="clarification">
+<p>Style properties which apply to text children or <loc href="#terms-anonymous-span">anonymous span</loc>
+children of a <el>span</el> element that functions as a <termref def="defs-ruby-container">ruby container</termref>,
+<termref def="defs-ruby-base-container">ruby base container</termref>, or <termref def="defs-ruby-text-container">ruby text container</termref>
+have no semantic affect during presentation processing since no significant text node appears as a child (or as a child of an
+<loc href="#terms-anonymous-span">anonymous span</loc> child) of such a <el>span</el> element. For example,
+if a <loc href="#style-attribute-fontStyle"><att>tts:fontStyle</att></loc> attribute is specified on such a <el>span</el> element,
+then it has no significant text node in scope to which it may be applied. Note, however, that a value specified for
+<loc href="#style-attribute-fontStyle"><att>tts:fontStyle</att></loc> on such a <el>span</el> element still applies for the purpose of
+<loc href="#semantics-style-inheritance">style inheritance</loc>.</p>
+</note>
 </div4>
 </div3>
 <div3 id="style-attribute-rubyAlign">


### PR DESCRIPTION
Closes #1043.