### PR TITLE
Correct the sRGB EOTF gamma in the HDR compositing example (Annex Q.1)

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -28964,12 +28964,11 @@ application based on <bibref ref="html52"/>), rather than of the Document Instan
 <div2 id="pq-hdr">
 <head>Perceptual Quantizer</head>
 <p>
-The following is intended to illustrate the use of <loc href="#style-attribute-luminanceGain"><att>tts:luminanceGain</att></loc> to composite <bibref ref="srgb"/> pixels onto HDR pixels
+The following illustrates the use of <loc href="#style-attribute-luminanceGain"><att>tts:luminanceGain</att></loc> to composite <bibref ref="srgb"/> pixels onto HDR pixels
 that conform to the system colorimetry specified in <bibref ref="bt2100_1"/> using perceptual quantizer (PQ) EOTF and full-range quantization.
 </p>
 <note role="elaboration">
-<p>The following example is intended to illustrate the application of <loc href="#style-attribute-luminanceGain"><att>tts:luminanceGain</att></loc>, 
-and is not intended to provide generic color management and be applicable to all situations, e.g. it assumes the target compositing 
+<p>The following example is not intended to provide generic color management and be applicable to all situations, e.g. it assumes the target compositing 
 surface is 10-bit and uses full-range quantization.</p>
 </note>
 <olist>

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -28964,9 +28964,14 @@ application based on <bibref ref="html52"/>), rather than of the Document Instan
 <div2 id="pq-hdr">
 <head>Perceptual Quantizer</head>
 <p>
-The following illustrates the use of <loc href="#style-attribute-luminanceGain"><att>tts:luminanceGain</att></loc> to composite <bibref ref="srgb"/> pixels onto HDR pixels
+The following is intended to illustrate the use of <loc href="#style-attribute-luminanceGain"><att>tts:luminanceGain</att></loc> to composite <bibref ref="srgb"/> pixels onto HDR pixels
 that conform to the system colorimetry specified in <bibref ref="bt2100_1"/> using perceptual quantizer (PQ) EOTF and full-range quantization.
 </p>
+<note role="elaboration">
+<p>The following example is intended to illustrate the application of <loc href="#style-attribute-luminanceGain"><att>tts:luminanceGain</att></loc>, 
+and is not intended to provide generic color management and be applicable to all situations, e.g. it assumes the target compositing 
+surface is 10-bit and uses full-range quantization.</p>
+</note>
 <olist>
 <item>
 <p>
@@ -28987,9 +28992,9 @@ Invert the 8-bit full-range quantization:
 </item>
 <item>
 <p>
-Linearize using the <bibref ref="srgb"/> EOTF:
+Linearize using the <bibref ref="srgb"/> reference display EOTF:
 </p><p>
-<code>(r<sup>2.4</sup>, g<sup>2.4</sup>, b<sup>2.4</sup>) → (r, g, b)</code>
+<code>(r<sup>2.2</sup>, g<sup>2.2</sup>, b<sup>2.2</sup>) → (r, g, b)</code>
 </p>
 </item>
 <item>


### PR DESCRIPTION
Closes #1070 