### PR TITLE
Ignore text node children of ruby container spans (#1076).

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -12094,7 +12094,9 @@ if the computed value of <att>tts:ruby</att> of a <loc href="#content-vocabulary
 <item><p>the computed value of <att>tts:ruby</att> of each of its child elements is not <code>none</code>;</p></item>
 <item><p>the computed value of <att>tts:ruby</att> of its first child element is <code>baseContainer</code>
 or <code>base</code>;</p></item>
-<item><p>each of its text node children contain only <loc href="#style-value-lwsp">&lt;lwsp&gt;</loc>;</p></item>
+<item><p>each of its text node children contain only <loc href="#style-value-lwsp">&lt;lwsp&gt;</loc>,
+which must be ignored for the purpose of presentation processing regardless of whether the computed value of the
+<loc href="#content-attribute-xml-space"><att>xml:space</att></loc> attribute is <code>preserve</code> or not;</p></item>
 </ulist>
 <p>When using <att>tts:ruby</att>, the following nesting constraints apply to a <termref def="defs-ruby-base-container">ruby base container</termref>, that is,
 if the computed value of <att>tts:ruby</att> of a <loc href="#content-vocabulary-span"><el>span</el></loc> element is <code>baseContainer</code>, then:</p>
@@ -12103,7 +12105,9 @@ if the computed value of <att>tts:ruby</att> of a <loc href="#content-vocabulary
 <item><p>the computed value of <att>tts:ruby</att> of each of its child elements is not <code>none</code>;</p></item>
 <item><p>the computed value of <att>tts:ruby</att> of its first child element is <code>base</code>;</p></item>
 <item><p>its preceding sibling is <code>null</code> (i.e., no preceding sibling);</p></item>
-<item><p>each of its text node children contain only <loc href="#style-value-lwsp">&lt;lwsp&gt;</loc>;</p></item>
+<item><p>each of its text node children contain only <loc href="#style-value-lwsp">&lt;lwsp&gt;</loc>,
+which must be ignored for the purpose of presentation processing regardless of whether the computed value of the
+<loc href="#content-attribute-xml-space"><att>xml:space</att></loc> attribute is <code>preserve</code> or not;</p></item>
 </ulist>
 <p>When using <att>tts:ruby</att>, the following nesting constraints apply to a <termref def="defs-ruby-text-container">ruby text container</termref>, that is,
 if the computed value of <att>tts:ruby</att> of a <loc href="#content-vocabulary-span"><el>span</el></loc> element is <code>textContainer</code>, then:</p>
@@ -12114,7 +12118,9 @@ if the computed value of <att>tts:ruby</att> of a <loc href="#content-vocabulary
 <item><p>the computed value of <att>tts:ruby</att> of its preceding sibling is <code>baseContainer</code> or
 <code>textContainer</code>;</p></item>
 <item><p>the computed value of <att>tts:ruby</att> of no more than one of its siblings is <code>textContainer</code>;</p></item>
-<item><p>each of its text node children contain only <loc href="#style-value-lwsp">&lt;lwsp&gt;</loc>;</p></item>
+<item><p>each of its text node children contain only <loc href="#style-value-lwsp">&lt;lwsp&gt;</loc>,
+which must be ignored for the purpose of presentation processing regardless of whether the computed value of the
+<loc href="#content-attribute-xml-space"><att>xml:space</att></loc> attribute is <code>preserve</code> or not;</p></item>
 </ulist>
 <p>When using <att>tts:ruby</att>, the following nesting constraints apply to <termref def="defs-ruby-base-content">ruby base content</termref>, that is,
 if the computed value of <att>tts:ruby</att> of a <loc href="#content-vocabulary-span"><el>span</el></loc> element is <code>base</code>, then:</p>
@@ -12160,7 +12166,7 @@ computed value of <att>tts:ruby</att> of no descendant element is not <code>none
 For the purpose of presentation processing, the violation of any of these constraints should result in fallback (inline)
 presentation of ruby text annotations, and, for content that violates some constraint, if that content is
 a <loc href="#content-vocabulary-br"><el>br</el></loc> element or a U+2028 (LINE SEPARATOR) or U+2029 (PARAGRAPH SEPARATOR) character,
-then it should be mapped to a U+0020 (SPACE) character, of, if some other content, then ignored (not presented).</p>
+then it should be mapped to a U+0020 (SPACE) character, or, if some other content, then ignored (not presented).</p>
 <note role="elaboration">
 <p>The above listed constraints are intended to be interpreted as specifying the following nesting model:</p>
 <eg xml:space="preserve">


### PR DESCRIPTION
This PR (and associated issue) break out the specific changes found in PR #1069 with respect to presentation semantics of text node children of ruby container spans.

Closes #1076.