### PR TITLE
Clarify use of 'applies to' in style property definition tables (#1088).

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -8375,9 +8375,7 @@ whether (and how) style is animatable, and semantic basis (derivation).</p>
 <note role="elaboration">
 <p>For the purpose of interpreting the entries of a
 <termref def="defs-style-property-definition-table">style property definition table</termref>, the definition of <emph>applies to</emph>
-specified by <bibref ref="css2"/>, &sect;1.4.2.3, applies to this specification as well. Moreover, the information described by the
-<emph>applies to</emph> entries of these tables are intended to be of a general nature, where the details of the semantics of style application
-are delegated to the prose that defines each style property.</p>
+specified by <bibref ref="css2"/>, &sect;1.4.2.3, applies to this specification.</p>
 </note>
 <p>For animatable styles, the term <emph>discrete</emph> refers to the use of either a <loc href="#animation-vocabulary-set"><el>set</el></loc>
 element or an <loc href="#animation-vocabulary-animate"><el>animate</el></loc> element with the <code>discrete</code> value for its

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -8372,6 +8372,13 @@ that support inline style specifications:</p>
 specifies one or more of the following aspects of the style: value syntax, initial value,
 elements to which style semantically applies, whether style is inherited or not, how percentage values are interpreted (if applicable),
 whether (and how) style is animatable, and semantic basis (derivation).</p>
+<note role="elaboration">
+<p>For the purpose of interpreting the entries of a
+<termref def="defs-style-property-definition-table">style property definition table</termref>, the definition of <emph>applies to</emph>
+specified by <bibref ref="css2"/>, &sect;1.4.2.3, applies to this specification as well. Moreover, the information described by the
+<emph>applies to</emph> entries of these tables are intended to be of a general nature, where the details of the semantics of style application
+are delegated to the prose that defines each style property.</p>
+</note>
 <p>For animatable styles, the term <emph>discrete</emph> refers to the use of either a <loc href="#animation-vocabulary-set"><el>set</el></loc>
 element or an <loc href="#animation-vocabulary-animate"><el>animate</el></loc> element with the <code>discrete</code> value for its
 <loc href="#animation-value-calculation-mode">&lt;calculation-mode&gt;</loc>. The term <emph>continuous</emph> refers to


### PR DESCRIPTION
Closes #1088.