### PR TITLE
Remove redundant feature dependency from #ruby-full (#1025).

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -22005,7 +22005,6 @@ supports the following features:</p>
 <ulist>
 <item><p><loc href="#feature-ruby"><code>#ruby</code></loc></p></item>
 <item><p><loc href="#feature-rubyAlign"><code>#rubyAlign</code></loc></p></item>
-<item><p><loc href="#feature-rubyAlign-withBase"><code>#rubyAlign-withBase</code></loc></p></item>
 <item><p><loc href="#feature-rubyPosition"><code>#rubyPosition</code></loc></p></item>
 <item><p><loc href="#feature-rubyReserve"><code>#rubyReserve</code></loc></p></item>
 </ulist>
@@ -22013,7 +22012,6 @@ supports the following features:</p>
 but prohibit use of any of the following features:
 <loc href="#feature-ruby"><code>#ruby</code></loc>,
 <loc href="#feature-rubyAlign"><code>#rubyAlign</code></loc>,
-<loc href="#feature-rubyAlign-withBase"><code>#rubyAlign-withBase</code></loc>,
 <loc href="#feature-rubyPosition"><code>#rubyPosition</code></loc>, or
 <loc href="#feature-rubyReserve"><code>#rubyReserve</code></loc>.</p>
 </div3>


### PR DESCRIPTION
Closes #1025.