### PR TITLE
Ignore linear whitespace in data and chunk element #PCDATA (#1003).

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -7270,6 +7270,8 @@ If no <code>clipEnd</code> attribute is specified, then a value equal to the int
 </table>
 <p>If an <loc href="#embedded-content-attribute-encoding"><att>encoding</att></loc> attribute is specified, then it must denote the actual encoding of the byte sequence represented by the
 <el>chunk</el> element. If no <loc href="#embedded-content-attribute-encoding"><att>encoding</att></loc> attribute is specified, then the encoding must be considered to be <code>base64</code>.</p>
+<p>Any linear whitespace (<loc href="#style-value-lwsp">&lt;lwsp&gt;</loc>)
+character present in the <code>#PCDATA</code> content of this element must be ignored when performing decoding processing.</p>
 <p>If a <att>length</att> attribute is specified, then it must denote the number of decoded bytes in the byte sequence represented by the
 <el>chunk</el> element. When decoding, if a specified length value does not match the number of decoded bytes, then the chunk and its container <el>data</el>
 element must return a zero length byte sequence.
@@ -7377,6 +7379,8 @@ If chunked or sourced data embedding is used, i.e., the content of the <el>data<
 <loc href="#embedded-content-vocabulary-chunk">chunk</loc> or <loc href="#embedded-content-vocabulary-source">source</loc> element, then
 an <loc href="#embedded-content-attribute-encoding"><att>encoding</att></loc> attribute must not be specified, and, if specified, must be ignored
 for the purpose of content processing.</p>
+<p>Furthermore, if simple data embedding is used, then any linear whitespace (<loc href="#style-value-lwsp">&lt;lwsp&gt;</loc>)
+character present in the <code>#PCDATA</code> content of this element must be ignored when performing decoding processing.</p>
 <p>If a <att>length</att> attribute is specified, then it must denote the number of decoded bytes in the byte sequence represented by the
 <el>data</el> element. When decoding, if a specified length value does not match the number of decoded bytes, then a zero length byte sequence must be returned.
 If no <att>length</att> attribute is specified, then the data resource is considered to have a length equal to the actual number of decoded bytes.

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -2105,7 +2105,7 @@ are also explicitly called out in specification text.</p>
 fragment, using the Kleene operators <code>?</code>, <code>*</code>
 and <code>+</code>. Each element name therein is a hyperlink to its
 own illustration.</p>
-<p>The term linear white-space (LWSP) is to be interpreted as a non-empty sequence of
+<p>The term linear whitespace (LWSP) is to be interpreted as a non-empty sequence of
 SPACE (U+0020), TAB (U+0009), CARRIAGE RETURN (U+000D), or LINE FEED (U+000A),
 which corresponds to production [3] <code>S</code> as defined by <bibref ref="xml10"/>.</p>
 <p>The following conventions are used in the specification of value syntax expressions:</p>
@@ -18954,7 +18954,7 @@ requirements that apply to the attribute targeted by the animation.</p>
 <head>&lt;key-splines&gt;</head>
 <p>A &lt;key-splines&gt; expression is used to specify a list of Bezier control points that control the pacing of an
 animation, wherein each pair of values is separated by a SEMICOLON (U+003B) character
-optionally surrounded by linear white-space (LWSP) characters.</p>
+optionally surrounded by linear whitespace (LWSP) characters.</p>
 <table id="key-splines-syntax" role="syntax">
 <caption>Syntax Representation &ndash; &lt;key-splines&gt;</caption>
 <tbody>
@@ -18989,7 +18989,7 @@ whole, fraction
 <head>&lt;key-times&gt;</head>
 <p>An &lt;key-times&gt; expression is used to specify a list of relative time values that control the pacing of an
 animation, wherein each pair of values is separated by a SEMICOLON (U+003B) character
-optionally surrounded by linear white-space (LWSP) characters.</p>
+optionally surrounded by linear whitespace (LWSP) characters.</p>
 <table id="key-times-syntax" role="syntax">
 <caption>Syntax Representation &ndash; &lt;key-times&gt;</caption>
 <tbody>


### PR DESCRIPTION
Closes #1003.