### PR TITLE
Eliminate inconsistent use of xsd:nonNegativeInteger (#983).

### DIFF
--- a/spec/rnc/ttml2-datatypes.rnc
+++ b/spec/rnc/ttml2-datatypes.rnc
@@ -72,7 +72,7 @@ TTAF.DataFormat.datatype =
   TTAF.URI.datatype
 
 TTAF.DataLength.datatype =
-  xsd:nonNegativeInteger
+  string
 
 TTAF.DataSource.datatype =
   TTAF.URI.datatype
@@ -164,7 +164,7 @@ TTAF.FragmentIdentifier.datatype =
   xsd:anyURI
 
 TTAF.FrameRate.datatype =
-  xsd:positiveInteger
+  string
 
 TTAF.FrameRateMultiplier.datatype =
   xsd:string { pattern = "\p{Nd}+\s+\p{Nd}+" }
@@ -344,7 +344,7 @@ TTAF.Speak.datatype =
   "slow"
   
 TTAF.SubFrameRate.datatype =
-  xsd:positiveInteger
+  string
 
 TTAF.TextAlign.datatype =
   "left" |
@@ -446,7 +446,7 @@ TTAF.TextShadow.datatype =
   string
 
 TTAF.TickRate.datatype =
-  xsd:positiveInteger
+  string
 
 TTAF.TimeBase.datatype =
   "media" |

--- a/spec/rnc/ttml2-datatypes.rnc
+++ b/spec/rnc/ttml2-datatypes.rnc
@@ -47,7 +47,7 @@ TTAF.CalcMode.datatype =
   "spline"
 
 TTAF.CellResolution.datatype =
-  string
+  xsd:string { pattern = "\p{Nd}+\s+\p{Nd}+" }
 
 TTAF.ClockMode.datatype =
   "local" |
@@ -164,7 +164,7 @@ TTAF.FragmentIdentifier.datatype =
   xsd:anyURI
 
 TTAF.FrameRate.datatype =
-  string
+  xsd:string { pattern = "\p{Nd}+" }
 
 TTAF.FrameRateMultiplier.datatype =
   xsd:string { pattern = "\p{Nd}+\s+\p{Nd}+" }
@@ -337,6 +337,9 @@ TTAF.ShowBackground.datatype =
   "always" |
   "whenActive"
 
+TTAF.Size.datatype =
+  xsd:string { pattern = "\p{Nd}+" }
+
 TTAF.Speak.datatype =
   "none" |
   "normal" |
@@ -344,7 +347,7 @@ TTAF.Speak.datatype =
   "slow"
   
 TTAF.SubFrameRate.datatype =
-  string
+  xsd:string { pattern = "\p{Nd}+" }
 
 TTAF.TextAlign.datatype =
   "left" |
@@ -446,7 +449,7 @@ TTAF.TextShadow.datatype =
   string
 
 TTAF.TickRate.datatype =
-  string
+  xsd:string { pattern = "\p{Nd}+" }
 
 TTAF.TimeBase.datatype =
   "media" |
@@ -484,6 +487,9 @@ TTAF.ValidationAction.datatype =
   "abort" |
   "warn" |
   "ignore"
+
+TTAF.Version.datatype =
+  xsd:string { pattern = "\p{Nd}+" }
 
 TTAF.Visibility.datatype =
   "hidden" |

--- a/spec/rnc/ttml2-isd.rnc
+++ b/spec/rnc/ttml2-isd.rnc
@@ -7,6 +7,11 @@ namespace ttp = "http://www.w3.org/ns/ttml#parameter"
 namespace tts = "http://www.w3.org/ns/ttml#styling"
 namespace local = ""
 
+TTAF.size.attrib
+  = attribute size { TTAF.Size.datatype }?
+TTAF.version.attrib
+  = attribute version { TTAF.Version.datatype }?
+
 TTAF.isd.parameter.attrib.class &=
   TTAF.cellResolution.attrib,
   TTAF.displayAspectRatio.attrib,
@@ -30,9 +35,9 @@ TTAF.isd.sequence =
   }
 
 TTAF.isd.sequence.attlist &=
-  attribute extent { string }?,
-  attribute size { xsd:nonNegativeInteger }?,
-  attribute version { xsd:nonNegativeInteger }?,
+  TTAF.extent.attrib,
+  TTAF.size.attrib,
+  TTAF.version.attrib,
   TTAF.base.attrib,
   TTAF.id.attrib,
   TTAF.lang.required.attrib,
@@ -54,10 +59,10 @@ TTAF.isd.isd =
   }
 
 TTAF.isd.isd.attlist &=
-  attribute begin { string },
-  attribute end { string },
-  attribute extent { string }?,
-  attribute version { xsd:nonNegativeInteger }?,
+  TTAF.timing.begin.attrib,
+  TTAF.timing.end.attrib,
+  TTAF.extent.attrib,
+  TTAF.version.attrib,
   TTAF.base.attrib,
   TTAF.id.attrib,
   TTAF.lang.attrib,
@@ -99,7 +104,7 @@ TTAF.isd.region =
   }
 
 TTAF.isd.region.attlist &=
-  attribute style { xsd:IDREF }?,
+  TTAF.style.attrib,
   TTAF.base.attrib,
   TTAF.id.required.attrib,
   TTAF.lang.attrib,

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -8109,7 +8109,7 @@ use tokens in common use, or absent that, to add a prefix <code>"x-"</code> to f
 </div3>
 <div3 id="embedded-content-value-font">
 <head>&lt;font&gt;</head>
-<p>An &lt;font&gt; expression is used to specify a <loc href="#terms-font-resource">font resource</loc> by reference.</p>
+<p>A &lt;font&gt; expression is used to specify a <loc href="#terms-font-resource">font resource</loc> by reference.</p>
 <table id="font-value-expression-syntax" role="syntax">
 <caption>Syntax Representation &ndash; &lt;font&gt;</caption>
 <tbody>
@@ -15536,7 +15536,7 @@ non-negative-real
 </div3>
 <div3 id="style-value-number">
 <head>&lt;number&gt;</head>
-<p>An &lt;number&gt; expression is used to express an arbitrary, optionally signed integer or real valued number.</p>
+<p>A &lt;number&gt; expression is used to express an arbitrary, optionally signed integer or real valued number.</p>
 <table id="number-style-expression-syntax" role="syntax">
 <caption>Syntax Representation &ndash; &lt;number&gt;</caption>
 <tbody>
@@ -15603,7 +15603,7 @@ are considered to be equal to the numeric value zero (0).</p>
 </div3>
 <div3 id="style-value-percentage">
 <head>&lt;percentage&gt;</head>
-<p>An &lt;percentage&gt; expression is used to express an arbitrary, signed integer or real valued percentage.</p>
+<p>A &lt;percentage&gt; expression is used to express an arbitrary, signed integer or real valued percentage.</p>
 <table id="percentage-style-expression-syntax" role="syntax">
 <caption>Syntax Representation &ndash; &lt;percentage&gt;</caption>
 <tbody>
@@ -19014,7 +19014,7 @@ whole, fraction
 </div3>
 <div3 id="animation-value-key-times">
 <head>&lt;key-times&gt;</head>
-<p>An &lt;key-times&gt; expression is used to specify a list of relative time values that control the pacing of an
+<p>A &lt;key-times&gt; expression is used to specify a list of relative time values that control the pacing of an
 animation, wherein each pair of values is separated by a SEMICOLON (U+003B) character
 optionally surrounded by linear white-space (LWSP) characters.</p>
 <table id="key-times-syntax" role="syntax">

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -2067,7 +2067,7 @@ as in the following:</p>
 <td>
 <eg xml:space="preserve">
 &lt;example
-  <phrase role="reqattr">count</phrase> = <loc href="http://www.w3.org/TR/xmlschema-2/#integer">xsd:integer</loc>
+  <phrase role="reqattr">count</phrase> = <loc href="#style-value-integer">&lt;integer&gt;</loc>
   size = (<emph>"large"</emph> | <emph>"medium"</emph> | <emph>"small"</emph> | <emph><phrase role="deprecated">"tiny"</phrase></emph> | <emph><phrase role="obsoleted">"micro"</phrase></emph>) : medium&gt;
   <emph>Content:</emph> (all | any*)
 &lt;/example&gt;
@@ -7266,7 +7266,7 @@ If no <code>clipEnd</code> attribute is specified, then a value equal to the int
 &lt;chunk
   <loc href="#content-attribute-condition">condition</loc> = <loc href="#content-value-condition">&lt;condition&gt;</loc>
   <loc href="#embedded-content-attribute-encoding">encoding</loc> = (<emph>"base16"</emph> | <emph>"base32"</emph> | <emph>"base32hex"</emph> | <emph>"base64"</emph> | <emph>"base64url"</emph>) : base64
-  length = <loc href="http://www.w3.org/TR/xmlschema-2/#nonNegativeInteger">xsd:nonNegativeInteger</loc>
+  length = <loc href="#style-value-non-negative-integer">&lt;non-negative-integer&gt;</loc>
   <loc href="#content-attribute-xml-base">xml:base</loc> = <loc href="#content-value-uri">&lt;uri&gt;</loc>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <emph>Content:</emph> #PCDATA
@@ -7364,7 +7364,7 @@ contain a <loc href="#embedded-content-vocabulary-data"><el>data</el></loc> elem
   <loc href="#content-attribute-condition">condition</loc> = <loc href="#content-value-condition">&lt;condition&gt;</loc>
   <loc href="#embedded-content-attribute-encoding">encoding</loc> = (<emph>"base16"</emph> | <emph>"base32"</emph> | <emph>"base32hex"</emph> | <emph>"base64"</emph> | <emph>"base64url"</emph>) : <emph>see prose below</emph>
   <loc href="#embedded-content-attribute-format">format</loc> = <loc href="#embedded-content-value-data-format">&lt;data-format&gt;</loc>
-  length = <loc href="http://www.w3.org/TR/xmlschema-2/#nonNegativeInteger">xsd:nonNegativeInteger</loc>
+  length = <loc href="#style-value-non-negative-integer">&lt;non-negative-integer&gt;</loc>
   <loc href="#embedded-content-attribute-src">src</loc> = <loc href="#embedded-content-value-data">&lt;data&gt;</loc>
   <loc href="#embedded-content-attribute-type">type</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc> : <emph>see prose below</emph>
   <loc href="#content-attribute-xml-base">xml:base</loc> = <loc href="#content-value-uri">&lt;uri&gt;</loc>
@@ -15282,7 +15282,7 @@ that employ base 16 arithmetic.</p>
 </div3>
 <div3 id="style-value-integer">
 <head>&lt;integer&gt;</head>
-<p>An &lt;integer&gt; expression is used to express an arbitrary, signed integral value.</p>
+<p>An &lt;integer&gt; expression is used to express an arbitrary, signed integer value.</p>
 <table id="integer-style-expression-syntax" role="syntax">
 <caption>Syntax Representation &ndash; &lt;integer&gt;</caption>
 <tbody>
@@ -15290,12 +15290,19 @@ that employ base 16 arithmetic.</p>
 <td>
 <eg xml:space="preserve">
 &lt;integer&gt;
-  : ( "+" | "-" )? <loc href="#style-value-non-negative-integer">&lt;non-negative-integer&gt;</loc>
+  : sign? <loc href="#style-value-non-negative-integer">&lt;non-negative-integer&gt;</loc>
+
+sign
+  : "+" | "-"
 </eg>
 </td>
 </tr>
 </tbody>
 </table>
+<note role="clarification">
+<p>The values of the lexical representations <attval>-0</attval>, <attval>0</attval>, and <attval>+0</attval>,
+regardless of the presence of additional leading or trailing <attval>0</attval> digits, are considered to be equal to the integer value zero (0).</p>
+</note>
 </div3>
 <div3 id="style-value-length">
 <head>&lt;length&gt;</head>
@@ -15546,6 +15553,14 @@ sign
 </tr>
 </tbody>
 </table>
+<note role="clarification">
+<p>The values of the lexical representations
+<attval>-0</attval>, <attval>-0.</attval>, <attval>-.0</attval>, <attval>-0.0</attval>,
+<attval>0</attval>, <attval>0.</attval>, <attval>.0</attval>, <attval>0.0</attval>,
+<attval>+0</attval>, <attval>+0.</attval>, <attval>+.0</attval>, and <attval>+0.0</attval>,
+regardless of the presence of additional leading or trailing <attval>0</attval> digits,
+are considered to be equal to the numeric value zero (0).</p>
+</note>
 </div3>
 <div3 id="style-value-origin">
 <head>&lt;origin&gt;</head>
@@ -15588,7 +15603,7 @@ sign
 </div3>
 <div3 id="style-value-percentage">
 <head>&lt;percentage&gt;</head>
-<p>An &lt;percentage&gt; expression is used to express an arbitrary, signed integral or real valued percentage.</p>
+<p>An &lt;percentage&gt; expression is used to express an arbitrary, signed integer or real valued percentage.</p>
 <table id="percentage-style-expression-syntax" role="syntax">
 <caption>Syntax Representation &ndash; &lt;percentage&gt;</caption>
 <tbody>
@@ -19745,7 +19760,7 @@ a <loc href="#metadata-vocabulary-item"><el>ttm:item</el></loc> element.</p>
 <label><code>altText</code></label>
 <def>
 <p>A string that expresses alternate text content, where the value
-adheres to <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>. Typically used to
+adheres to <loc href="http://www.w3.org/TR/xmlschema-2/#string"><code>xsd:string</code></loc>. Typically used to
 provide a text equivalent or summary for some related image content.</p>
 <note role="elaboration"><p>This text equivalent may be used to support indexing of the content and also facilitate
 quality checking of a document during authoring.</p></note>
@@ -19759,7 +19774,7 @@ content cannot be presented; however, this alternate text content can be used by
 <def>
 <p>A boolean that expresses whether some <loc href="#content-value-condition">&lt;condition&gt;</loc> expression
 makes use of the <loc href="#bound-parameter-forced"><code>forced</code></loc> bound parameter, where the value
-adheres to <loc href="http://www.w3.org/TR/xmlschema-2/#boolean">xsd:boolean</loc>. If this named metadata item
+adheres to <loc href="http://www.w3.org/TR/xmlschema-2/#boolean"><code>xsd:boolean</code></loc>. If this named metadata item
 is present in a <loc href="#terms-document-instance">document instance</loc>, then it must be specified as a child
 of the <loc href="#document-structure-vocabulary-head"><el>head</el></loc> element.</p>
 </def>
@@ -25295,8 +25310,8 @@ begin time; furthermore, the temporal intervals of any two child <loc href="#isd
 <eg xml:space="preserve">
 &lt;isd:sequence
   extent = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  size = <loc href="http://www.w3.org/TR/xmlschema-2/#nonNegativeInteger">xsd:nonNegativeInteger</loc>
-  version = <loc href="http://www.w3.org/TR/xmlschema-2/#positiveInteger">xsd:positiveInteger</loc>
+  size = <loc href="#style-value-non-negative-integer">&lt;non-negative-integer&gt;</loc>
+  version = <loc href="#style-value-non-negative-integer">&lt;non-negative-integer&gt;</loc>
   <loc href="#content-attribute-xml-base">xml:base</loc> = <loc href="#content-value-uri">&lt;uri&gt;</loc>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang"><phrase role="reqattr">xml:lang</phrase></loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
@@ -25322,7 +25337,7 @@ may be determined by inspection.</p>
 <note role="elaboration">
 <p>The <att>size</att> attribute would normally be omitted in the case of real time captioning.</p>
 </note>
-<p>If the <att>version</att> attribute is specified, then it must be a positive integer corresponding to the version of this
+<p>If the <att>version</att> attribute is specified, then it must be a positive integer (greater than zero) corresponding to the version of this
 <loc href="#terms-intermediate-document-syntax">Intermediate Synchronic Document Syntax</loc> specification used in authoring
 the ISD sequence document. If specified, the numeric value must be greater than or equal to two (2). If not specified, then the version must be
 consider to be equal to two (2). The version associated with this
@@ -25381,7 +25396,7 @@ followed by zero or more <loc href="#isd-vocabulary-region"><el>isd:region</el><
   <loc href="#timing-attribute-begin"><phrase role="reqattr">begin</phrase></loc> = <loc href="#timing-value-time-expression">&lt;time-expression&gt;</loc>
   <loc href="#timing-attribute-end"><phrase role="reqattr">end</phrase></loc> = <loc href="#timing-value-time-expression">&lt;time-expression&gt;</loc> | <emph>"indefinite"</emph>
   extent = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>
-  version = <loc href="http://www.w3.org/TR/xmlschema-2/#positiveInteger">xsd:positiveInteger</loc>
+  version = <loc href="#style-value-non-negative-integer">&lt;non-negative-integer&gt;</loc>
   <loc href="#content-attribute-xml-base">xml:base</loc> = <loc href="#content-value-uri">&lt;uri&gt;</loc>
   <loc href="#content-attribute-xml-id">xml:id</loc> = ID
   <loc href="#content-attribute-xml-lang">xml:lang</loc> = <loc href="http://www.w3.org/TR/xmlschema-2/#string">xsd:string</loc>

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -5241,7 +5241,7 @@ ttp:cellResolution
   : columns <loc href="#style-value-lwsp">&lt;lwsp&gt;</loc> rows                     // <emph>columns</emph> != 0; <emph>rows</emph> != 0
 
 columns | rows
-  : <loc href="#style-value-digit">&lt;digit&gt;</loc>+
+  : <loc href="#style-value-non-negative-integer">&lt;non-negative-integer&gt;</loc>
 </eg>
 </td>
 </tr>
@@ -5348,7 +5348,7 @@ ttp:displayAspectRatio
   : numerator <loc href="#style-value-lwsp">&lt;lwsp&gt;</loc> denominator            // <emph>numerator</emph> != 0; <emph>denominator</emph> != 0
 
 numerator | denominator
-  : <loc href="#style-value-digit">&lt;digit&gt;</loc>+
+  : <loc href="#style-value-non-negative-integer">&lt;non-negative-integer&gt;</loc>
 </eg>
 </td>
 </tr>
@@ -5453,7 +5453,7 @@ to function as an independent media object.</p>
 <td>
 <eg xml:space="preserve">
 ttp:frameRate
-  : <loc href="#style-value-digit">&lt;digit&gt;</loc>+                                // <emph>value</emph> > 0
+  : <loc href="#style-value-non-negative-integer">&lt;non-negative-integer&gt;</loc>                                // <emph>value</emph> > 0
 </eg>
 </td>
 </tr>
@@ -5496,7 +5496,7 @@ ttp:frameRateMultiplier
   : numerator <loc href="#style-value-lwsp">&lt;lwsp&gt;</loc> denominator            // <emph>numerator</emph> != 0; <emph>denominator</emph> != 0
 
 numerator | denominator
-  : <loc href="#style-value-digit">&lt;digit&gt;</loc>+
+  : <loc href="#style-value-non-negative-integer">&lt;non-negative-integer&gt;</loc>
 </eg>
 </td>
 </tr>
@@ -5647,7 +5647,7 @@ ttp:pixelAspectRatio
   : numerator <loc href="#style-value-lwsp">&lt;lwsp&gt;</loc> denominator            // <emph>numerator</emph> != 0; <emph>denominator</emph> != 0
 
 numerator | denominator
-  : <loc href="#style-value-digit">&lt;digit&gt;</loc>+
+  : <loc href="#style-value-non-negative-integer">&lt;non-negative-integer&gt;</loc>
 </eg>
 </td>
 </tr>
@@ -5676,7 +5676,7 @@ to function as an independent media object.</p>
 <td>
 <eg xml:space="preserve">
 ttp:subFrameRate
-  : <loc href="#style-value-digit">&lt;digit&gt;</loc>+                                // <emph>value</emph> > 0
+  : <loc href="#style-value-non-negative-integer">&lt;non-negative-integer&gt;</loc>                                // <emph>value</emph> > 0
 </eg>
 </td>
 </tr>
@@ -5717,7 +5717,7 @@ to function as an independent media object.</p>
 <td>
 <eg xml:space="preserve">
 ttp:tickRate
-  : <loc href="#style-value-digit">&lt;digit&gt;</loc>+                                // <emph>value</emph> > 0
+  : <loc href="#style-value-non-negative-integer">&lt;non-negative-integer&gt;</loc>                                // <emph>value</emph> > 0
 </eg>
 </td>
 </tr>
@@ -19003,7 +19003,7 @@ coordinate                                // 0 &ge; <emph>value</emph> &ge; 1
   | "." fraction
 
 whole, fraction
-  : <loc href="#style-value-digit">&lt;digit&gt;</loc>+
+  : <loc href="#style-value-non-negative-integer">&lt;non-negative-integer&gt;</loc>
 </eg>
 </td>
 </tr>
@@ -19032,7 +19032,7 @@ time                                // 0 &ge; <emph>value</emph> &ge; 1
   | "." fraction
 
 whole, fraction
-  : <loc href="#style-value-digit">&lt;digit&gt;</loc>+
+  : <loc href="#style-value-non-negative-integer">&lt;non-negative-integer&gt;</loc>
 </eg>
 </td>
 </tr>
@@ -19060,7 +19060,7 @@ count:
   | "." fraction
 
 whole, fraction
-  : <loc href="#style-value-digit">&lt;digit&gt;</loc>+
+  : <loc href="#style-value-non-negative-integer">&lt;non-negative-integer&gt;</loc>
 </eg>
 </td>
 </tr>

--- a/spec/xsd/ttml2-datatypes.xsd
+++ b/spec/xsd/ttml2-datatypes.xsd
@@ -69,7 +69,9 @@
     <xs:annotation>
       <xs:documentation>non-negative-integer non-negative-integer</xs:documentation>
     </xs:annotation>
-    <xs:restriction base="xs:string"/>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="\p{Nd}+\s+\p{Nd}+"/>
+    </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="clockMode">
     <xs:restriction base="xs:token">
@@ -107,7 +109,9 @@
     <xs:annotation>
       <xs:documentation>non-negative-integer</xs:documentation>
     </xs:annotation>
-    <xs:restriction base="xs:string"/>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="\p{Nd}+"/>
+    </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="dataSource">
     <xs:restriction base="xs:anyURI"/>
@@ -272,7 +276,9 @@
     <xs:annotation>
       <xs:documentation>non-negative-integer</xs:documentation>
     </xs:annotation>
-    <xs:restriction base="xs:string"/>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="\p{Nd}+"/>
+    </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="frameRateMultiplier">
     <xs:annotation>
@@ -281,6 +287,12 @@
     <xs:restriction base="xs:string">
       <xs:pattern value="\p{Nd}+\s+\p{Nd}+"/>
     </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="gain">
+    <xs:annotation>
+      <xs:documentation>number</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>   
   </xs:simpleType>
   <xs:simpleType name="inferProcessorProfileMethod">
     <xs:restriction base="xs:token">
@@ -312,7 +324,7 @@
           | "." fraction
 
         whole, fraction
-          : digit+
+          : non-negative-integer
 
         comma
           : ","
@@ -335,7 +347,7 @@
           | "." fraction
 
         whole, fraction
-          : digit+
+          : non-negative-integer
 
         lwsp
           : ( ' ' | '\t' | '\n' | '\r' )+
@@ -446,8 +458,27 @@
     </xs:annotation>
     <xs:restriction base="xs:string"/>
   </xs:simpleType>
+  <xs:simpleType name="pan">
+    <xs:annotation>
+      <xs:documentation>number</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
   <xs:simpleType name="permitFeatureNarrowingOrWidening">
     <xs:restriction base="xs:boolean"/>
+  </xs:simpleType>
+  <xs:simpleType name="pitch">
+    <xs:annotation>
+      <xs:documentation>
+        pitch
+          : percentage
+          | number pitch-units?
+
+        pitch-units
+          : "hz" | "st"
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
   </xs:simpleType>
   <xs:simpleType name="pixelAspectRatio">
     <xs:annotation>
@@ -487,7 +518,7 @@
     <xs:annotation>
       <xs:documentation>
         repeatCount
-          : count                          // value > 0
+          : count                          // value &gt; 0
           | "indefinite"
 
         count:
@@ -496,7 +527,7 @@
           | "." fraction
 
         whole, fraction
-          : digit+
+          : non-negative-integer
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string"/>
@@ -568,11 +599,29 @@
       <xs:enumeration value="whenActive"/>
     </xs:restriction>
   </xs:simpleType>
+  <xs:simpleType name="size">
+    <xs:annotation>
+      <xs:documentation>non-negative-integer</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="\p{Nd}+"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="speak">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="none"/>
+      <xs:enumeration value="normal"/>
+      <xs:enumeration value="fast"/>
+      <xs:enumeration value="slow"/>
+    </xs:restriction>
+  </xs:simpleType>
   <xs:simpleType name="subFrameRate">
     <xs:annotation>
       <xs:documentation>non-negative-integer</xs:documentation>
     </xs:annotation>
-    <xs:restriction base="xs:string"/>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="\p{Nd}+"/>
+    </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="textAlign">
     <xs:restriction base="xs:token">
@@ -697,7 +746,9 @@
     <xs:annotation>
       <xs:documentation>non-negative-integer</xs:documentation>
     </xs:annotation>
-    <xs:restriction base="xs:string"/>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="\p{Nd}+"/>
+    </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="timeBase">
     <xs:restriction base="xs:token">
@@ -746,6 +797,16 @@
       <xs:enumeration value="ignore"/>
     </xs:restriction>
   </xs:simpleType>
+  <xs:simpleType name="version">
+    <xs:annotation>
+      <xs:documentation>
+        non-negative-integer               // value &gt; 0
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="\p{Nd}+"/>
+    </xs:restriction>
+  </xs:simpleType>
   <xs:simpleType name="visibility">
     <xs:restriction base="xs:token">
       <xs:enumeration value="hidden"/>
@@ -774,22 +835,5 @@
       <xs:documentation>auto | integer</xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string"/>
-  </xs:simpleType>
-  <xs:simpleType name="gain">
-    <xs:restriction base="xs:string"/>   
-  </xs:simpleType>
-  <xs:simpleType name="pan">
-    <xs:restriction base="xs:string"/>
-  </xs:simpleType>
-  <xs:simpleType name="pitch">
-    <xs:restriction base="xs:string"/>
-  </xs:simpleType>
-  <xs:simpleType name="speak">
-    <xs:restriction base="xs:token">
-      <xs:enumeration value="none"/>
-      <xs:enumeration value="normal"/>
-      <xs:enumeration value="fast"/>
-      <xs:enumeration value="slow"/>
-    </xs:restriction>
   </xs:simpleType>
 </xs:schema>

--- a/spec/xsd/ttml2-datatypes.xsd
+++ b/spec/xsd/ttml2-datatypes.xsd
@@ -67,7 +67,7 @@
   </xs:simpleType>
   <xs:simpleType name="cellResolution">
     <xs:annotation>
-      <xs:documentation>positiveInteger positiveInteger</xs:documentation>
+      <xs:documentation>non-negative-integer non-negative-integer</xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string"/>
   </xs:simpleType>
@@ -104,7 +104,10 @@
     </xs:union>
   </xs:simpleType>
   <xs:simpleType name="dataLength">
-    <xs:restriction base="xs:nonNegativeInteger"/>
+    <xs:annotation>
+      <xs:documentation>non-negative-integer</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
   </xs:simpleType>
   <xs:simpleType name="dataSource">
     <xs:restriction base="xs:anyURI"/>
@@ -141,7 +144,7 @@
   </xs:simpleType>
   <xs:simpleType name="displayAspectRatio">
     <xs:annotation>
-      <xs:documentation>positiveInteger positiveInteger</xs:documentation>
+      <xs:documentation>non-negative-integer non-negative-integer</xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
       <xs:pattern value="\p{Nd}+\s+\p{Nd}+"/>
@@ -266,11 +269,14 @@
     <xs:restriction base="xs:anyURI"/>
   </xs:simpleType>
   <xs:simpleType name="frameRate">
-    <xs:restriction base="xs:positiveInteger"/>
+    <xs:annotation>
+      <xs:documentation>non-negative-integer</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
   </xs:simpleType>
   <xs:simpleType name="frameRateMultiplier">
     <xs:annotation>
-      <xs:documentation>positiveInteger positiveInteger</xs:documentation>
+      <xs:documentation>non-negative-integer non-negative-integer</xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
       <xs:pattern value="\p{Nd}+\s+\p{Nd}+"/>
@@ -445,7 +451,7 @@
   </xs:simpleType>
   <xs:simpleType name="pixelAspectRatio">
     <xs:annotation>
-      <xs:documentation>positiveInteger:positiveInteger</xs:documentation>
+      <xs:documentation>non-negative-integer non-negative-integer</xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
       <xs:pattern value="\p{Nd}+\s+\p{Nd}+"/>
@@ -563,7 +569,10 @@
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="subFrameRate">
-    <xs:restriction base="xs:positiveInteger"/>
+    <xs:annotation>
+      <xs:documentation>non-negative-integer</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
   </xs:simpleType>
   <xs:simpleType name="textAlign">
     <xs:restriction base="xs:token">
@@ -685,7 +694,10 @@
     <xs:restriction base="xs:string"/>
   </xs:simpleType>
   <xs:simpleType name="tickRate">
-    <xs:restriction base="xs:positiveInteger"/>
+    <xs:annotation>
+      <xs:documentation>non-negative-integer</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
   </xs:simpleType>
   <xs:simpleType name="timeBase">
     <xs:restriction base="xs:token">

--- a/spec/xsd/ttml2-isd.xsd
+++ b/spec/xsd/ttml2-isd.xsd
@@ -4,6 +4,7 @@
   xmlns:tt="http://www.w3.org/ns/ttml"
   xmlns:ttm="http://www.w3.org/ns/ttml#metadata"
   xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+  xmlns:ttd="http://www.w3.org/ns/ttml#datatype"
   xmlns:tts="http://www.w3.org/ns/ttml#styling"
   xmlns:isd="http://www.w3.org/ns/ttml#isd">
   <xs:import namespace="http://www.w3.org/ns/ttml"
@@ -18,6 +19,8 @@
     schemaLocation="ttml2-animation.xsd"/>
   <xs:import namespace="http://www.w3.org/XML/1998/namespace"
     schemaLocation="xml.xsd"/>
+  <xs:import namespace="http://www.w3.org/ns/ttml#datatype"
+    schemaLocation="ttml2-datatypes.xsd"/>
   <xs:attributeGroup name="isd.parameter.attrib.class">
     <xs:attribute ref="ttp:cellResolution"/>
     <xs:attribute ref="ttp:displayAspectRatio"/>
@@ -35,8 +38,8 @@
   </xs:attributeGroup>
   <xs:attributeGroup name="sequence.attlist">
     <xs:attribute name="extent" type="xs:string"/>
-    <xs:attribute name="size" type="xs:nonNegativeInteger"/>
-    <xs:attribute name="version" type="xs:nonNegativeInteger"/>
+    <xs:attribute name="size" type="ttd:size"/>
+    <xs:attribute name="version" type="ttd:version"/>
     <xs:attribute ref="xml:base"/>
     <xs:attribute ref="xml:id"/>
     <xs:attribute ref="xml:lang" use="required"/>
@@ -55,7 +58,7 @@
     <xs:attribute name="begin" type="xs:string" use="required"/>
     <xs:attribute name="end" type="xs:string" use="required"/>
     <xs:attribute name="extent" type="xs:string"/>
-    <xs:attribute name="version" type="xs:nonNegativeInteger"/>
+    <xs:attribute name="version" type="ttd:version"/>
     <xs:attribute ref="xml:base"/>
     <xs:attribute ref="xml:id"/>
     <xs:attribute ref="xml:lang"/>


### PR DESCRIPTION
Closes #983.

In addition to eliminating the use of `xsd:nonNegativeInteger`, this PR

- eliminates use of `xsd:positiveInteger`
- adds notes regarding value equivalence of `-0`, `0`, `+0`, etc.
- improves editorial consistency
