### PR TITLE
Remove references to XML 1.1 (#1158).

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -7059,7 +7059,7 @@ escape
 </table>
 <note role="elaboration">
 <p>For avoidance of doubt, take note that linear whitespace (LWSP) is permitted in a quoted string expression, but that it
-is subject to <loc href="https://www.w3.org/TR/2006/REC-xml11-20060816/#AVNormalize">XML Attribute-Value Normalization</loc>
+is subject to <bibref ref="xml10"/>, &sect;3.3.3, <emph>Attribute-Value Normalization</emph>,
 when constructing a <loc href="#terms-reduced-xml-infoset">reduced xml infoset</loc> from a
 <loc href="#terms-timed-text-content-document-instance">timed text document instance</loc>.</p>
 </note>
@@ -19838,7 +19838,7 @@ extension-role
   : "x-" token-char+
 
 token-char
-  : { XML NameChar }    // <bibref ref="xml11"/> Production [4a]
+  : { XML NameChar }    // <bibref ref="xml10"/> Production [4a]
 </eg>
 </td>
 </tr>
@@ -20096,7 +20096,7 @@ designation
   : "#" token-char+
 
 token-char
-  : { XML NameChar }                        // <bibref ref="xml11"/> Production [4a]
+  : { XML NameChar }                        // <bibref ref="xml10"/> Production [4a]
 </eg>
 <p>All values of <code>feature-designation</code> not defined by this specification are reserved
 for future standardization.</p>
@@ -24697,7 +24697,7 @@ designation
   : "#" token-char+
 
 token-char
-  : { XML NameChar }                        // <bibref ref="xml11"/> Production [4a]
+  : { XML NameChar }                        // <bibref ref="xml10"/> Production [4a]
 </eg>
 <p>If the extension namespace of an extension designation is the TT
 Extension Namespace, then all values of the following
@@ -25948,11 +25948,6 @@ W3C Recommendation, 04 February 2004. (See
 <titleref href="http://www.w3.org/TR/2009/REC-xml-names-20091208/">Namespaces
 in XML 1.0 (Third Edition)</titleref>, W3C Recommendation, 8 December 2009. (See
 <xspecref href="http://www.w3.org/TR/2009/REC-xml-names-20091208/">http://www.w3.org/TR/2009/REC-xml-names-20091208/</xspecref>.)
-</bibl>
-<bibl id="xml11" key="XML 1.1">Tim Bray, et al.
-<titleref href="http://www.w3.org/TR/2006/REC-xml11-20060816/">Extensible Markup Language (XML)
-1.1 (Second Edition)</titleref>, W3C Recommendation, 16 August 2006, edited in place 29 September 2006. (See
-<xspecref href="http://www.w3.org/TR/2006/REC-xml11-20060816/">http://www.w3.org/TR/2006/REC-xml11-20060816/</xspecref>.)
 </bibl>
 <bibl id="xsd-1" key="XML Schema Part 1">Henry S. Thompson, David Beech,
 Murray Maloney, Noah Mendelsohn, Eds.,


### PR DESCRIPTION
Closes #1158.

N.B. that even though this PR removes a normative bibliographic entry from the specification, it replaces the textual references to this normative reference with references to identical content in XML 1.0 5e, and, therefore, is strictly editorial in nature.