### PR TITLE
Fix syntax coloring problem by using character ref for apostrophe.

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -8,7 +8,7 @@
 <!ENTITY prevloc "https://www.w3.org/TR/2018/REC-ttml2-20181108/">
 <!ENTITY latestedloc "https://w3c.github.io/ttml2/index.html">
 <!ENTITY versionOfTT "2">
-<!ENTITY tbd "<phrase role='tbd'>To Be Defined</phrase>">
+<!ENTITY tbd "<phrase role=&apos;tbd&apos;>To Be Defined</phrase>">
 <!ENTITY sp "&#x0020;">
 <!ENTITY sect "&#x00a7;">
 <!ENTITY times "&#x00d7;">
@@ -52,7 +52,7 @@
 <!ENTITY profile-ttml2-transformation SYSTEM "./profiles/ttml2-transformation.xml.esc">
 <!ENTITY profile-ttml2-full SYSTEM "./profiles/ttml2-full.xml.esc">
 ]>
-<?xml-stylesheet type='text/xsl' href='xmlspec-ttml2.xsl'?>
+<?xml-stylesheet type="text/xsl" href="xmlspec-ttml2.xsl"?>
 <spec w3c-doctype="&doctype;" role="&document.role;" canonical-url="&w3c-designation;">
 <header>
 <title>&title;</title>
@@ -158,7 +158,7 @@ element in an <bibref ref="html52"/> document, or a <el>&lt;text&gt;</el> or
 ref="smil3"/> document.</p>
 </abstract>
 &status;
-<langusage><language id='en-us'>English</language></langusage>
+<langusage><language id="en-us">English</language></langusage>
 <revisiondesc><p>Commit: $Date$</p></revisiondesc>
 </header>
 <body>
@@ -2162,8 +2162,8 @@ defined in <bibref ref="xsd-2"/>, a hyperlink to its definition
 therein is given.</p>
 <p>Unqualified attributes are not permitted unless explicitly defined in this specification.</p>
 <note role="elaboration"><p>With the exception of <specref ref="element-derivation"/>, the (possibly namespace qualified) name of an attribute
-is prefixed with a '<code>@</code>' (COMMERCIAL AT) character in order to disambiguate between the attribute and a like-named element type, in which case
-the '<code>@</code>' character is not intended to be part of the literal name of the attribute. For example, <code>@ttm:agent</code>
+is prefixed with a &apos;<code>@</code>&apos; (COMMERCIAL AT) character in order to disambiguate between the attribute and a like-named element type, in which case
+the &apos;<code>@</code>&apos; character is not intended to be part of the literal name of the attribute. For example, <code>@ttm:agent</code>
 refers to the <loc href="#metadata-attribute-agent">ttm:agent</loc> attribute, while <code>ttm:agent</code> refers to
 <loc href="#metadata-vocabulary-agent">ttm:agent</loc> element.</p></note>
 <p>An information item depicted with a <phrase role="deprecated">light yellow orange</phrase> background color is deprecated (e.g.,
@@ -3358,11 +3358,11 @@ procedure;</p>
 <p>for each profile specification, <emph>S</emph>, in the <loc href="#semantics-profile-state-combined-profile-specification-set">combined profile specification set</loc> <emph>CPSS</emph>:</p>
 <olist>
 <item>
-<p>map content profile specification <emph>S</emph> to processor profile specification <emph>S'&nbsp;</emph> according to the computed
+<p>map content profile specification <emph>S</emph> to processor profile specification <emph>S&apos;&nbsp;</emph> according to the computed
 value of the <att>ttp:inferPresentationProfileMethod</att> parameter and <specref ref="infer-processor-profile-method-table"/>;</p>
 </item>
 <item>
-<p>add <emph>S'&nbsp;</emph> to the <loc href="#semantics-profile-state-profile-combined-specification-set">combined specification set</loc> of <emph>IPP</emph>;</p>
+<p>add <emph>S&apos;&nbsp;</emph> to the <loc href="#semantics-profile-state-profile-combined-specification-set">combined specification set</loc> of <emph>IPP</emph>;</p>
 </item>
 </olist>
 </item>
@@ -4210,8 +4210,8 @@ feature or extension specifications.</p>
 <p>The <loc href="#semantics-profile-state-combined-profile-specification-set">combined profile specification set</loc> <emph>CPSS</emph> of features and extensions of a profile <emph>P</emph>
 is determined according to the following ordered rules, where merging a specification <emph>S</emph>
 into <emph>CPSS</emph> entails applying a combination method in accordance with the specified
-(or default) value of the <att>combine</att> attribute, and where merging a <loc href="#semantics-profile-state-combined-profile-specification-set">combined profile specification set</loc> <emph>CPSS'&nbsp;</emph> into
-<emph>CPSS</emph> entails merging each ordered specification of <emph>CPSS'&nbsp;</emph> into <emph>CPSS</emph>:</p>
+(or default) value of the <att>combine</att> attribute, and where merging a <loc href="#semantics-profile-state-combined-profile-specification-set">combined profile specification set</loc> <emph>CPSS&apos;&nbsp;</emph> into
+<emph>CPSS</emph> entails merging each ordered specification of <emph>CPSS&apos;&nbsp;</emph> into <emph>CPSS</emph>:</p>
 <olist>
 <item><p>initialize <emph>CPSS</emph> to the empty set;</p></item>
 <item><p>if a <att>use</att> attribute is present, then merge
@@ -4378,7 +4378,7 @@ absolute URI.  In either case (original absolute URI or resulting
 element must further adhere to the syntax of a feature designation as
 defined by <specref ref="feature-designations"/>, and, furthermore,
 the specific designation that appears in this URI, i.e., the portion of the feature designation
-that starts with the fragment identifier separator '#', must
+that starts with the fragment identifier separator &apos;#&apos;, must
 be defined by this specification or some published version thereof (that
 has achieved REC status).</p>
 <p>If the URI expressed by the content of the <el>ttp:feature</el> element,
@@ -6937,7 +6937,7 @@ string-literal
 </table>
 <note role="elaboration">
 <p>For avoidance of doubt, take note that no linear whitespace (LWSP) is permitted between the <code>identifier</code> token and the initial open
-parenthesis '<code>(</code>' character of the following <loc href="#content-value-arguments">&lt;arguments&gt;</loc> expression of a
+parenthesis &apos;<code>(</code>&apos; character of the following <loc href="#content-value-arguments">&lt;arguments&gt;</loc> expression of a
 <code>function-expression</code>.</p>
 </note>
 </div3>
@@ -7066,15 +7066,14 @@ specified parameter name.</p>
   | single-quoted-string
 
 double-quoted-string
-  : '"' ([^"\\] | escape)* '"'
+  : &apos;&quot;&apos; ([^&quot;\\] | escape)* &apos;&quot;&apos;
 
 single-quoted-string
-  : "'" ([^'\\] | escape)* "'"
+  : &quot;&apos;&quot; ([^&apos;\\] | escape)* &quot;&apos;&quot;
 
 escape
-  : '\\' <emph>char</emph>
+  : &apos;\\&apos; <emph>char</emph>
 </eg>
-<!-- " -->
 </td>
 </tr>
 </tbody>
@@ -8383,7 +8382,7 @@ model. TTML Processors are not required to present <loc href="#terms-document-in
 but an implementation of this model by a TTML <loc href="#terms-presentation-processor">presentation processor</loc>
 that provides externally observable results that are consistent with this model is
 likely to lead to a user experience that closely resembles the experience intended by
-the documents' authors.</p>
+the documents&apos; authors.</p>
 <note role="explanation">
 <p>The semantics of TTML style presentation are described in terms of the layout and formatting model defined
 in <bibref ref="xslfo11"/>. The effects of the attributes in this section 
@@ -8834,7 +8833,7 @@ defines the background color of a region or an area generated by content flowed 
 ...
 &lt;p region="r1" <phrase role="strong">tts:backgroundColor="purple"</phrase> tts:textAlign="center"&gt;
   Twinkle, twinkle, little bat!&lt;br/&gt;
-  How &lt;span <phrase role="strong">tts:backgroundColor="green"</phrase>&gt;I wonder&lt;/span&gt; where you're at!
+  How &lt;span <phrase role="strong">tts:backgroundColor="green"</phrase>&gt;I wonder&lt;/span&gt; where you&apos;re at!
 &lt;/p&gt;
 </eg>
 </td>
@@ -9403,7 +9402,7 @@ is minimized.</p>
 ...
 &lt;p region="r1" <phrase role="strong">tts:border="4px solid green"</phrase> tts:textAlign="center"&gt;
   Twinkle, twinkle, little bat!&lt;br/&gt;
-  How &lt;span <phrase role="strong">tts:border="8px solid blue"</phrase>&gt;I wonder&lt;/span&gt; where you're at!
+  How &lt;span <phrase role="strong">tts:border="8px solid blue"</phrase>&gt;I wonder&lt;/span&gt; where you&apos;re at!
 &lt;/p&gt;
 </eg>
 </td>
@@ -9608,7 +9607,7 @@ background color of the <loc href="#terms-root-container-region">root container 
 ...
 &lt;p region="r1"&gt;
   In spring, when woods are &lt;span <phrase role="strong">tts:color="green"</phrase>&gt;getting green&lt;/span&gt;,&lt;br/&gt;
-  I'll try and tell you what I mean.
+  I&apos;ll try and tell you what I mean.
 &lt;/p&gt;
 </eg>
 </td>
@@ -10239,7 +10238,7 @@ while use of a smaller extent makes region overflow more likely.</p>
 &lt;/region&gt;
 ...
 &lt;p region="r1"&gt;
-  'Tis the voice of the Lobster:&lt;br/&gt;
+  &apos;Tis the voice of the Lobster:&lt;br/&gt;
   I heard him declare,&lt;br/&gt;
   "You have baked me too brown,&lt;br/&gt;
   I must sugar my hair."
@@ -10336,8 +10335,8 @@ use the value <code>default</code>.</p>
 ...
 &lt;div region="r1"&gt;
   &lt;p&gt;
-    "The time has come," the Walrus said,&lt;br/&gt;
-    "to talk of many things:
+    &quot;The time has come,&quot; the Walrus said,&lt;br/&gt;
+    &quot;to talk of many things:
   &lt;/p&gt;
   &lt;p tts:textAlign="end" <phrase role="strong">tts:fontFamily="monospaceSerif"</phrase>&gt;
     Of shoes, and ships, and sealing wax,&lt;br/&gt;
@@ -10345,11 +10344,10 @@ use the value <code>default</code>.</p>
   &lt;/p&gt;
   &lt;p&gt;
     And why the sea is boiling hot,&lt;br/&gt;
-    and whether pigs have wings."
+    and whether pigs have wings.&quot;
   &lt;/p&gt;
 &lt;/div&gt;
 </eg>
-<!-- " -->
 </td>
 </tr>
 </tbody>
@@ -13076,28 +13074,28 @@ made to these leadings as needed to accommodate the presence of actual <termref 
 <tbody>
 <tr>
 <td><code>none</code></td>
-<td><graphic source="images/rubyReserve_1A_none.png" alt="TTML rubyReserve style property: 'auto'" css="width: 230px; height: 240px"/></td>
-<td><graphic source="images/rubyReserve_1B_none.png" alt="TTML rubyReserve style property: 'auto'" css="width: 230px; height: 240px"/></td>
+<td><graphic source="images/rubyReserve_1A_none.png" alt="TTML rubyReserve style property: &apos;auto&apos;" css="width: 230px; height: 240px"/></td>
+<td><graphic source="images/rubyReserve_1B_none.png" alt="TTML rubyReserve style property: &apos;auto&apos;" css="width: 230px; height: 240px"/></td>
 </tr>
 <tr>
 <td><code>before</code></td>
-<td><graphic source="images/rubyReserve_3A_before.png" alt="TTML rubyReserve style property: 'after'" css="width: 230px; height: 213px"/></td>
-<td><graphic source="images/rubyReserve_3B_before.png" alt="TTML rubyReserve style property: 'after'" css="width: 230px; height: 213px"/></td>
+<td><graphic source="images/rubyReserve_3A_before.png" alt="TTML rubyReserve style property: &apos;after&apos;" css="width: 230px; height: 213px"/></td>
+<td><graphic source="images/rubyReserve_3B_before.png" alt="TTML rubyReserve style property: &apos;after&apos;" css="width: 230px; height: 213px"/></td>
 </tr>
 <tr>
 <td><code>after</code></td>
-<td><graphic source="images/rubyReserve_4A_after.png" alt="TTML rubyReserve style property: 'after'" css="width: 230px; height: 213px"/></td>
-<td><graphic source="images/rubyReserve_4B_after.png" alt="TTML rubyReserve style property: 'after'" css="width: 230px; height: 213px"/></td>
+<td><graphic source="images/rubyReserve_4A_after.png" alt="TTML rubyReserve style property: &apos;after&apos;" css="width: 230px; height: 213px"/></td>
+<td><graphic source="images/rubyReserve_4B_after.png" alt="TTML rubyReserve style property: &apos;after&apos;" css="width: 230px; height: 213px"/></td>
 </tr>
 <tr>
 <td><code>both</code></td>
-<td><graphic source="images/rubyReserve_5A_both.png" alt="TTML rubyReserve style property: 'after'" css="width: 230px; height: 267px"/></td>
-<td><graphic source="images/rubyReserve_5B_both.png" alt="TTML rubyReserve style property: 'after'" css="width: 230px; height: 267px"/></td>
+<td><graphic source="images/rubyReserve_5A_both.png" alt="TTML rubyReserve style property: &apos;after&apos;" css="width: 230px; height: 267px"/></td>
+<td><graphic source="images/rubyReserve_5B_both.png" alt="TTML rubyReserve style property: &apos;after&apos;" css="width: 230px; height: 267px"/></td>
 </tr>
 <tr>
 <td><code>outside</code></td>
-<td><graphic source="images/rubyReserve_6A_outside.png" alt="TTML rubyReserve style property: 'after'" css="width: 230px; height: 213px"/></td>
-<td><graphic source="images/rubyReserve_6B_outside.png" alt="TTML rubyReserve style property: 'after'" css="width: 230px; height: 213px"/></td>
+<td><graphic source="images/rubyReserve_6A_outside.png" alt="TTML rubyReserve style property: &apos;after&apos;" css="width: 230px; height: 213px"/></td>
+<td><graphic source="images/rubyReserve_6B_outside.png" alt="TTML rubyReserve style property: &apos;after&apos;" css="width: 230px; height: 213px"/></td>
 </tr>
 </tbody>
 </table>
@@ -13542,8 +13540,8 @@ value in any order, such as <code>"noUnderline overline lineThrough"</code>.</p>
   &lt;span <phrase role="strong">tts:textDecoration="noUnderline"</phrase>&gt;
     could be,&lt;br/&gt;
     The sand was dry as dry.&lt;br/&gt;
-    &lt;span <phrase role="strong">tts:textDecoration="lineThrough"</phrase>&gt;There weren't any&lt;/span&gt;
-    You &lt;span <phrase role="strong">tts:textDecoration="lineThrough"</phrase>&gt;couldn't&lt;/span&gt;
+    &lt;span <phrase role="strong">tts:textDecoration="lineThrough"</phrase>&gt;There weren&apos;t any&lt;/span&gt;
+    You &lt;span <phrase role="strong">tts:textDecoration="lineThrough"</phrase>&gt;couldn&apos;t&lt;/span&gt;
     could not see a cloud&lt;br/&gt;
     Because no cloud was in the sky.
   &lt;/span&gt;
@@ -14227,7 +14225,7 @@ then a <loc href="#terms-presentation-processor">presentation processor</loc> mu
 &lt;/region&gt;
 ...
 &lt;p&gt;
-  I'll tell thee everything I can:&lt;br/&gt;
+  I&apos;ll tell thee everything I can:&lt;br/&gt;
   There&apos;s little to relate.&lt;br/&gt;
   I saw an aged aged man,&lt;br/&gt;
   A-sitting on a gate.
@@ -15213,19 +15211,19 @@ equivalent to <code>filled circle</code>.</p>
 <gitem>
 <label><code>circle</code></label>
 <def>
-<p>Emphasis mark is a circle. If filled, then equivalent to U+25CF '&#x25CF;'; if open, then equivalent to U+25CB '&#x25CB;'</p>
+<p>Emphasis mark is a circle. If filled, then equivalent to U+25CF &apos;&#x25CF;&apos;; if open, then equivalent to U+25CB &apos;&#x25CB;&apos;</p>
 </def>
 </gitem>
 <gitem>
 <label><code>dot</code></label>
 <def>
-<p>Emphasis mark is a dot. If filled, then equivalent to U+2022 '&#x2022;'; if open, then equivalent to U+25E6 '&#x25E6;'</p>
+<p>Emphasis mark is a dot. If filled, then equivalent to U+2022 &apos;&#x2022;&apos;; if open, then equivalent to U+25E6 &apos;&#x25E6;&apos;</p>
 </def>
 </gitem>
 <gitem>
 <label><code>sesame</code></label>
 <def>
-<p>Emphasis mark is a sesame. If filled, then equivalent to U+FE45 '&#xFE45;'; if open, then equivalent to U+FE46 '&#xFE46;'</p>
+<p>Emphasis mark is a sesame. If filled, then equivalent to U+FE45 &apos;&#xFE45;&apos;; if open, then equivalent to U+FE46 &apos;&#xFE46;&apos;</p>
 </def>
 </gitem>
 <gitem>
@@ -16556,8 +16554,8 @@ given priority as described above by <specref ref="semantics-style-association-i
 </tbody>
 </table>
 <note role="explanation">
-<p>In the above example, the text of the second paragraph is yellow, since <code>tts:color='yellow'</code>
- effectively overwrites (is merged over) the <code>tts:color='white'</code> that style <code>s2</code> obtains by a reference to style
+<p>In the above example, the text of the second paragraph is yellow, since <code>tts:color="yellow"</code>
+ effectively overwrites (is merged over) the <code>tts:color="white"</code> that style <code>s2</code> obtains by a reference to style
   <code>s1</code>.</p>
 </note>
 </div4>
@@ -17592,31 +17590,31 @@ perform the following ordered steps:</p>
 <p>if the <code>[children]</code> information item property of <emph>B</emph> does not contain
 a <loc href="#layout-vocabulary-region"><el>region</el></loc> element <emph>R</emph>, then exit this procedure;</p>
 </item>
-<item><p>create an empty <loc href="#layout-vocabulary-region"><el>region</el></loc> element <emph>R'&nbsp;</emph>,
+<item><p>create an empty <loc href="#layout-vocabulary-region"><el>region</el></loc> element <emph>R&apos;&nbsp;</emph>,
 initialized as follows:</p>
 <ulist>
 <item>
-<p>set the <code>[children]</code> information item property of <emph>R'&nbsp;</emph> to a deep copy of
+<p>set the <code>[children]</code> information item property of <emph>R&apos;&nbsp;</emph> to a deep copy of
 the <code>[children]</code> information item property of <emph>R</emph>;</p>
 </item>
 <item>
-<p>set the <code>[attributes]</code> information item property of <emph>R'&nbsp;</emph> to a deep copy of
+<p>set the <code>[attributes]</code> information item property of <emph>R&apos;&nbsp;</emph> to a deep copy of
 the <code>[attributes]</code> information item property of <emph>R</emph>;</p>
 </item>
 <item>
-<p>if the <code>[attributes]</code> information item property of <emph>R'&nbsp;</emph> does not include
+<p>if the <code>[attributes]</code> information item property of <emph>R&apos;&nbsp;</emph> does not include
 an <att>xml:id</att> attribute, then add an implied <att>xml:id</att> attribute with a generated value
 <emph>ID</emph> that is unique within the scope of the TTML <loc href="#terms-document-instance">document instance</loc>;
-otherwise, let <emph>ID</emph> be the value of the <att>xml:id</att> attribute of <emph>R'&nbsp;</emph>;</p>
+otherwise, let <emph>ID</emph> be the value of the <att>xml:id</att> attribute of <emph>R&apos;&nbsp;</emph>;</p>
 </item>
 <item>
-<p>if present, remove the following attributes from the <code>[attributes]</code> information item property of <emph>R'&nbsp;</emph>:
+<p>if present, remove the following attributes from the <code>[attributes]</code> information item property of <emph>R&apos;&nbsp;</emph>:
 <att>begin</att>,
 <att>dur</att>, and
 <att>end</att>;</p>
 </item>
 <item>
-  <p>add <att>begin</att> and <att>end</att> attributes to the <code>[attributes]</code> information item property of <emph>R'&nbsp;</emph>
+  <p>add <att>begin</att> and <att>end</att> attributes to the <code>[attributes]</code> information item property of <emph>R&apos;&nbsp;</emph>
   as follows:</p>
   <olist>
     <item><p>if not operating in smpte time base and discontinuous marker mode, then set the values of these <att>begin</att> and <att>end</att>
@@ -17644,7 +17642,7 @@ a <loc href="#layout-vocabulary-layout"><el>layout</el></loc> child element, the
 the <loc href="#document-structure-vocabulary-head"><el>head</el></loc> element if neither are present;</p>
 </item>
 <item>
-<p>append <emph>R'&nbsp;</emph> to the <code>[children]</code> information item property of the
+<p>append <emph>R&apos;&nbsp;</emph> to the <code>[children]</code> information item property of the
 <loc href="#layout-vocabulary-layout"><el>layout</el></loc> element child of the 
 <loc href="#document-structure-vocabulary-head"><el>head</el></loc> element;</p>
 </item>
@@ -17785,7 +17783,7 @@ headed by the <el>body</el> element;</p>
 <!-- ttml1 uses "neither a <loc href="#element-vocab-type-content">Content</loc> nor <loc href="#element-vocab-type-animation">Animation</loc> elements" -->; or</p></item>
 <item><p>they are temporally inactive; or</p></item>
 <item><p>they are empty and neither <loc href="#element-vocab-type-animation">Animation</loc> elements nor <loc href="#content-vocabulary-br">br</loc> elements; or</p></item>
-<item><p>they <!-- ttml1 "are <loc href="#element-vocab-type-content">Content</loc> elements and" -->aren't associated with region <emph>R</emph>
+<item><p>they <!-- ttml1 "are <loc href="#element-vocab-type-content">Content</loc> elements and" -->aren&apos;t associated with region <emph>R</emph>
  according to the <phrase role="strong"><loc href="#procedure-associate-region">[associate region]</loc></phrase> procedure.</p></item>
 </olist>
 </item>
@@ -19073,9 +19071,9 @@ attribute.</p>
 <p>For each <loc href="#terms-out-of-line-animation">out-of-line animation</loc> element <emph>A</emph> referenced by the <att>animate</att>
 attribute of an element <emph>E</emph>, perform the following steps (in order of specified IDREFs):</p>
 <olist>
-<item><p>create a deep copy, <emph>A'</emph>, of <emph>A</emph>;</p></item>
-<item><p>remove the <loc href="#content-attribute-xml-id"><att>xml:id</att></loc> attribute from <emph>A'</emph>&nbsp;;</p></item>
-<item><p>insert <emph>A'</emph> into the <code>[children]</code> information item property of <emph>E</emph> such that <emph>A'</emph> appears
+<item><p>create a deep copy, <emph>A&apos;</emph>, of <emph>A</emph>;</p></item>
+<item><p>remove the <loc href="#content-attribute-xml-id"><att>xml:id</att></loc> attribute from <emph>A&apos;</emph>&nbsp;;</p></item>
+<item><p>insert <emph>A&apos;</emph> into the <code>[children]</code> information item property of <emph>E</emph> such that <emph>A&apos;</emph> appears
 as the last element in the subsequence of child elements that corresponds to the
 <code><loc href="#element-vocab-group-animation">Animation.class</loc>*</code> wildcard of the content model of <emph>E</emph>.</p></item>
 </olist>
@@ -19115,7 +19113,7 @@ or ending (final) of the attribute targeted by the animation.</p>
   : ([^;] | escape)+
 
 escape
-  : '\\' <emph>char</emph>
+  : &apos;\\&apos; <emph>char</emph>
 </eg>
 </td>
 </tr>
@@ -22999,7 +22997,7 @@ whether the designated feature must be implemented, i.e., is mandatory (M), or m
 is optional (O), for a TTML <loc href="#terms-content-processor">content processor</loc> that complies with the requirements of
 <specref ref="conformance-transformation-processor"/> or <specref ref="conformance-presentation-processor"/>.</p>
 <note role="clarification">
-  <p>In some cases, a new feature designation is defined in this (or a later) version of this specification that wasn't previously defined, and yet
+  <p>In some cases, a new feature designation is defined in this (or a later) version of this specification that wasn&apos;t previously defined, and yet
   the underlying functional feature so designated was previously defined by an earlier version. For example, the <code>#padding-region</code>
   designation is introduced here; however, the functionality it references was previously included under the designation <code>#padding</code>
   which is now defined in terms of <code>#padding-region</code>. Here, the underlying meaning of <code>#padding</code>, introduced in TTML1,
@@ -25218,7 +25216,7 @@ media time <phrase role="strong"><code>M</code></phrase> in accordance to the
 <slist>
 <sitem/>
 <sitem>
-If a time expression uses a <emph>clock-time</emph> form or an <emph>offset-time</emph> form that doesn't use the ticks (<code>t</code>) metric, then:
+If a time expression uses a <emph>clock-time</emph> form or an <emph>offset-time</emph> form that doesn&apos;t use the ticks (<code>t</code>) metric, then:
 </sitem>
 <sitem/>
 <sitem>
@@ -25287,7 +25285,7 @@ and <code>tickRate</code> is the computed value of the <att>ttp:tickRate</att> p
 </note>
 <note role="clarification">
 <p>The above formalisms assume that the begin time of the <loc href="#terms-document-temporal-coordinate-space">document temporal coordinate space</loc> is related to the
-begin time of a <loc href="#terms-related-media-object">related media object</loc>. If this assumption doesn't hold, then an additional offset
+begin time of a <loc href="#terms-related-media-object">related media object</loc>. If this assumption doesn&apos;t hold, then an additional offset
 that accounts for the difference may be introduced when computing media time <code>M</code>.</p>
 </note>
 </div3> <!-- semantics-media-timing -->
@@ -26078,7 +26076,7 @@ W3C Working Draft, 20 September 2018. (See
 W3C Candidate Recommendation, 03 July 2018. (See
 <xspecref href="https://www.w3.org/TR/2018/CR-css-text-decor-3-20180703/">https://www.w3.org/TR/2018/CR-css-text-decor-3-20180703/</xspecref>.)
 </bibl>
-<bibl id="css-transform" key="CSS Transforms">Simon Fraser, Dean Jackson, Theresa O'Connor, and Dirk Schulze,
+<bibl id="css-transform" key="CSS Transforms">Simon Fraser, Dean Jackson, Theresa O&apos;Connor, and Dirk Schulze,
 <titleref href="https://www.w3.org/TR/2017/WD-css-transforms-1-20171130/">CSS Transforms Module Level 1</titleref>,
 W3C Working Draft, 30 November 2017. (See
 <xspecref href="https://www.w3.org/TR/2017/WD-css-transforms-1-20171130/">https://www.w3.org/TR/2017/WD-css-transforms-1-20171130/</xspecref>.)

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -307,7 +307,7 @@ region to inherit from these styles.
 In <specref ref="ttml-example-layout"/>, the region definition makes
 reference to style specification <code>s1</code> augmented by specific inline
 styles which, together, allow content flowed into the region to inherit
-from the region's styles (in the case
+from the region&apos;s styles (in the case
 that a style is not already explicitly specified on content or inherited
 via the content hierarchy.)</p>
 <table id="ttml-example-layout" role="example">
@@ -436,7 +436,7 @@ semantic paragraphs.</p>
 </table>
 <p>The second subtitle continues with the default style, except that it contains
 two lines of text with an intervening author-specified line break. Note the effects of
-the use of <code>tts:textAlign="center"</code> to specify the paragraph's alignment
+the use of <code>tts:textAlign="center"</code> to specify the paragraph&apos;s alignment
 in the inline progression direction.</p>
 <table id="ttml-example-subtitle-2" role="example-images">
 <caption>Subtitle 2 &ndash; Time Interval [5.0, 10.0)</caption>
@@ -446,7 +446,7 @@ in the inline progression direction.</p>
 </tr>
 </tbody>
 </table>
-<p>The third subtitle continues, using a variant style which overrides the default style's
+<p>The third subtitle continues, using a variant style which overrides the default style&apos;s
 foreground color with a different color.</p>
 <table id="ttml-example-subtitle-3" role="example-images">
 <caption>Subtitle 3 &ndash; Time Interval [10.0, 16.0)</caption>
@@ -466,7 +466,7 @@ foreground color with a different color.</p>
 </tbody>
 </table>
 <p>The fifth subtitle continues, again using a variant style which
-overrides the default style's foreground color with a different color.</p>
+overrides the default style&apos;s foreground color with a different color.</p>
 <table id="ttml-example-subtitle-5" role="example-images">
 <caption>Subtitle 5 &ndash; Time Interval [23.0, 27.0)</caption>
 <tbody>
@@ -865,7 +865,7 @@ an <emph>unconditionally included</emph> element.</p>
 which see <loc href="#content-attribute-condition"><att>condition</att></loc> for the detailed semantics of conditional exclusion.</p>
 <note role="elaboration">
 <p>In the case of certain elements, for example the <loc href="#styling-vocabulary-style"><el>style</el></loc> element,
-conditional exclusion causes some but not all of the element's semantics to be ignored,
+conditional exclusion causes some but not all of the element&apos;s semantics to be ignored,
 in which case such behavior is described explicitly.</p>
 </note>
 </def>
@@ -1067,7 +1067,7 @@ explicitly or implicitly referenced by or assigned to a TTML <loc href="#terms-d
 explicit or implicit profile and profile specification combination methods, about which see the
 <loc href="#semantics-procedure-construct-effective-content-profile"><phrase role="strong">construct effective content profile</phrase></loc> procedure.
 When performing validation on a given <loc href="#terms-document-instance">document instance</loc>,
-then this validation is performed by making use of a document's <loc href="#terms-effective-content-profile">effective content profile</loc>.</p>
+then this validation is performed by making use of a document&apos;s <loc href="#terms-effective-content-profile">effective content profile</loc>.</p>
 </def>
 </gitem>
 <gitem id="terms-effective-processor-profile">
@@ -1079,7 +1079,7 @@ explicit or implicit profile and profile specification combination methods, abou
 <loc href="#semantics-procedure-construct-effective-processor-profile"><phrase role="strong">construct effective processor profile</phrase></loc> procedure.
 When determining if a <loc href="#terms-content-processor">content processor</loc>
 can or cannot process a given <loc href="#terms-document-instance">document instance</loc>, then this determination is performed
-by making use of a document's <loc href="#terms-effective-processor-profile">effective processor profile</loc>.</p>
+by making use of a document&apos;s <loc href="#terms-effective-processor-profile">effective processor profile</loc>.</p>
 </def>
 </gitem>
 <gitem id="terms-effective-validation-profile">
@@ -1376,7 +1376,7 @@ abbreviated as <emph>ipd</emph> or <emph>IPD</emph>.</p>
 An inline region is specified by a <loc href="#layout-vocabulary-region"><el>region</el></loc> element child of
 certain <loc href="#terms-content-element">content elements</loc>.
 There is a one-to-one relation between an inline <loc href="#layout-vocabulary-region"><el>region</el></loc> element and its
-parent <loc href="#terms-content-element">content element</loc>. An inline region is assigned its parent element's time interval as its active
+parent <loc href="#terms-content-element">content element</loc>. An inline region is assigned its parent element&apos;s time interval as its active
 time interval. No <att>region</att> attribute makes reference to an inline region.</p>
 </def>
 </gitem>
@@ -1428,7 +1428,7 @@ container area, and determining the width and height of the resulting, formatted
 <label>[intrinsic image extent]</label>
 <def>
 <p>The extent, i.e., width and height of an image determined from information internal to the image itself, e.g.,
-the width and height of the image's pixel array.</p>
+the width and height of the image&apos;s pixel array.</p>
 </def>
 </gitem>
 <gitem id="terms-intrinsic-inline-content-extent">
@@ -1783,13 +1783,13 @@ or <attval>textContainer</attval>.</p>
 <p>A significant text node is a <termref def="defs-text-node">text node</termref> that contains at least one
 <emph>significant</emph> <termref def="defs-data-character">data character</termref>,
 where the determination of whether a <termref def="defs-data-character">data character</termref> is significant or not is determined by the
-declared content model and the defined semantics of the element type of the <termref def="defs-text-node">text node's</termref>
+declared content model and the defined semantics of the element type of the <termref def="defs-text-node">text node&apos;s</termref>
 parent <termref def="defs-element-node">element node</termref>, more about which see <bibref ref="xml10"/>, &sect;3.2.
-In particular, if the content model of the parent's element type is
+In particular, if the content model of the parent&apos;s element type is
 <loc href="https://www.w3.org/TR/2008/REC-xml-20081126/#sec-element-content">element content</loc>,
-then no <termref def="defs-data-character">data character</termref> is significant; however, if the content model of the parent's element type is
+then no <termref def="defs-data-character">data character</termref> is significant; however, if the content model of the parent&apos;s element type is
 <loc href="https://www.w3.org/TR/2008/REC-xml-20081126/#sec-mixed-content">mixed content</loc>,
-then the semantics of the parent's element type and its applied style properties (as defined in this specification) determines whether
+then the semantics of the parent&apos;s element type and its applied style properties (as defined in this specification) determines whether
 a <termref def="defs-data-character">data character</termref> is significant (not ignored) or not (ignored) in some context of use.</p>
 <note role="clarification">
 <p>A <termdef id="defs-data-character" term=""><term>data character</term></termdef> is any character that is
@@ -2025,7 +2025,7 @@ no further transformation semantics are defined by this specification.</p>
 <label>[undesignated profile]</label>
 <def>
 <p>A <loc href="#terms-profile">profile</loc> that is not associated with a <loc href="#content-value-profile-designator">profile designator</loc>,
-and which is referred to implicitly in the context of the profile's definition. Also referred to as an <emph>anonymous profile</emph>.</p>
+and which is referred to implicitly in the context of the profile&apos;s definition. Also referred to as an <emph>anonymous profile</emph>.</p>
 </def>
 </gitem>
 <gitem id="terms-valid-abstract-document-instance">
@@ -2563,7 +2563,7 @@ by the associated <loc href="#terms-abstract-document-type">abstract document ty
 <item>
 <p>pruning character
 information item children from any remaining element in case that all
-character children of the element denote XML whitespace characters and the element's type
+character children of the element denote XML whitespace characters and the element&apos;s type
 is defined as empty in the associated <loc href="#terms-abstract-document-type">abstract document type</loc>, and then</p>
 </item>
 <item>
@@ -2578,7 +2578,7 @@ with their owning element information items,</p>
 <p>then the document element is one of the document
 element types permitted by the associated <loc href="#terms-abstract-document-type">abstract document type</loc>,
 the descendants of the document
-element satisfy their respective element type's content
+element satisfy their respective element type&apos;s content
 specifications, all required attributes are present, and the declared
 value of each attribute satisfies the type declared by the
 associated <loc href="#terms-abstract-document-type">abstract document type</loc>.</p>
@@ -2903,8 +2903,8 @@ a <loc href="#terms-processor">processor</loc> supports the <specref ref="featur
 <specref ref="feature-processorProfiles-combined"/> feature.</p>
 </note>
 <note role="elaboration">
-<p>Notwithstanding an author's declaration of their intention to use specific content or processor profiles, a <loc href="#terms-processor">processor</loc>
-is allowed to override the author's declaration of content and (or) processor profiles. This is expected to be typical behavior
+<p>Notwithstanding an author&apos;s declaration of their intention to use specific content or processor profiles, a <loc href="#terms-processor">processor</loc>
+is allowed to override the author&apos;s declaration of content and (or) processor profiles. This is expected to be typical behavior
 for <loc href="#terms-processor">processors</loc> that support only a single profile or a limited set of profiles, particularly when
 the <loc href="#terms-processor">processor</loc> is not able to dereference (download) and process a
 <loc href="#terms-profile-definition-document">profile definition document</loc> and does not support
@@ -3480,7 +3480,7 @@ that causes a warning to be treated as an error, or vice-versa.</p></note>
 <label>[construct effective validation profile]</label>
 <def>
 <olist>
-<item><p>if a document's <loc href="#terms-effective-content-profile">effective content profile</loc> is not <code>null</code>, then the
+<item><p>if a document&apos;s <loc href="#terms-effective-content-profile">effective content profile</loc> is not <code>null</code>, then the
 <loc href="#terms-effective-validation-profile">effective validation profile</loc> is the
 <loc href="#terms-effective-content-profile">effective content profile</loc>;</p></item>
 <item><p>otherwise, the <loc href="#terms-effective-validation-profile">effective validation profile</loc> is the
@@ -3498,7 +3498,7 @@ for the duration of that processing.</p>
 <label>[construct effective validation schemas]</label>
 <def>
 <olist>
-<item><p>if a document's <loc href="#terms-effective-validation-profile">effective validation profile</loc> is associated with one or more
+<item><p>if a document&apos;s <loc href="#terms-effective-validation-profile">effective validation profile</loc> is associated with one or more
 schemas, then the set of <loc href="#terms-effective-validation-schemas">effective validation schemas</loc> is an appropriate subset
 of these associated schemas based upon the requirements of the <loc href="#terms-document-processing-context">document processing context</loc>;</p></item>
 <item><p>otherwise, the <loc href="#terms-effective-validation-schemas">effective validation schemas</loc> is a default set of schemas selected by the
@@ -3537,7 +3537,7 @@ to the computed value of the <loc href="#profile-attribute-validationAction"><at
 <item><p>if the input document takes the form of a concrete XML representation, e.g., the concrete form defined by
 Appendix <specref ref="concrete-encoding"/>, then verify that</p>
 <ulist>
-<item><p>the encoded characters of the input document are well-formed according to the document's resolved character encoding; and,</p></item>
+<item><p>the encoded characters of the input document are well-formed according to the document&apos;s resolved character encoding; and,</p></item>
 <item><p>the input document is a well-formed XML document; and</p></item>
 </ulist>
 </item>
@@ -4322,7 +4322,7 @@ attribute must (1) adhere to the
 adheres to <bibref ref="xmlbase"/> and,
 (3) express a feature namespace as defined by
 <specref ref="feature-designations"/>. If not specified, the
-<att>xml:base</att> attribute's default
+<att>xml:base</att> attribute&apos;s default
 value applies, which is the TT Feature Namespace.</p>
 <p>The <att>xml:base</att> attribute is
 used to permit the abbreviation of feature designation URIs expressed
@@ -4528,7 +4528,7 @@ attribute must (1) adhere to the
 adheres to <bibref ref="xmlbase"/> and,
 (3) express an extension namespace as defined by
 <specref ref="extension-designations"/>. If not specified, the
-<att>xml:base</att> attribute's default
+<att>xml:base</att> attribute&apos;s default
 value applies, which is the TT Extension Namespace.</p>
 <p>The <att>xml:base</att> attribute is
 used to permit the abbreviation of feature designation URIs expressed
@@ -4897,9 +4897,9 @@ ttp:inferProcessorProfileMethod
 </tr>
 </tbody>
 </table>
-<p>If this parameter's value is <code>loose</code>, then, when inferring a processor profile specification from a content profile specification,
+<p>If this parameter&apos;s value is <code>loose</code>, then, when inferring a processor profile specification from a content profile specification,
 a loose (liberal) mapping applies.</p>
-<p>If this parameter's value is <code>strict</code>, then, when inferring a processor profile specification from a content profile specification,
+<p>If this parameter&apos;s value is <code>strict</code>, then, when inferring a processor profile specification from a content profile specification,
 a strict (conservative) mapping applies.</p>
 <p>If not specified, the value of this parameter must be considered
 to be <code>loose</code>.</p>
@@ -4956,9 +4956,9 @@ ttp:inferProcessorProfileSource
 </tr>
 </tbody>
 </table>
-<p>If this parameter's value is <code>combined</code>, then, when inferring a processor profile, the <loc href="#semantics-profile-state-profile-combined-specification-set">combined specification set</loc>
+<p>If this parameter&apos;s value is <code>combined</code>, then, when inferring a processor profile, the <loc href="#semantics-profile-state-profile-combined-specification-set">combined specification set</loc>
 of the <loc href="#terms-effective-content-profile">effective content profile</loc> is used as the source of inference.</p>
-<p>If this parameter's value is <code>first</code>, then, when inferring a processor profile, the first constituent profile of
+<p>If this parameter&apos;s value is <code>first</code>, then, when inferring a processor profile, the first constituent profile of
 the <loc href="#semantics-profile-state-profile-combined-specification-set">combined specification set</loc> of the <loc href="#terms-effective-content-profile">effective content profile</loc>,
 where the processor profile inferred from that constituent profile is supported by the <loc href="#terms-content-processor">content processor</loc>,
 is used as the source of inference, about which see the
@@ -4987,10 +4987,10 @@ ttp:permitFeatureNarrowing
 </tr>
 </tbody>
 </table>
-<p>If this parameter's value is <code>true</code>, then, a requirement for support of a feature or extension may be satisfied
+<p>If this parameter&apos;s value is <code>true</code>, then, a requirement for support of a feature or extension may be satisfied
 if the definition of the feature or extension specifies an <att>extends</att> attribute, and the feature or extension referenced
 by that attribute is supported by a processor.</p>
-<p>If this parameter's value is <code>false</code>, then, a requirement for support of a feature or extension can not be satisfied
+<p>If this parameter&apos;s value is <code>false</code>, then, a requirement for support of a feature or extension can not be satisfied
 by a more narrowly defined feature or extension specified by an <att>extends</att> attribute.</p>
 <p>If not specified, the value of this parameter must be considered
 to be <code>false</code>.</p>
@@ -5016,10 +5016,10 @@ ttp:permitFeatureWidening
 </tr>
 </tbody>
 </table>
-<p>If this parameter's value is <code>true</code>, then, a requirement for support of a feature or extension may be satisfied
+<p>If this parameter&apos;s value is <code>true</code>, then, a requirement for support of a feature or extension may be satisfied
 if the definition of the feature or extension specifies a <att>restricts</att> attribute, and the feature or extension referenced
 by that attribute is supported by a processor.</p>
-<p>If this parameter's value is <code>false</code>, then, a requirement for support of a feature or extension can not be satisfied
+<p>If this parameter&apos;s value is <code>false</code>, then, a requirement for support of a feature or extension can not be satisfied
 by a more widely defined feature or extension specified by a <att>restricts</att> attribute.</p>
 <p>If not specified, the value of this parameter must be considered
 to be <code>false</code>.</p>
@@ -5219,13 +5219,13 @@ ttp:validation
 </tr>
 </tbody>
 </table>
-<p>If this parameter's value is <code>required</code>, then, a <loc href="#terms-validating-content-processor">validating content processor</loc>
+<p>If this parameter&apos;s value is <code>required</code>, then, a <loc href="#terms-validating-content-processor">validating content processor</loc>
 must perform <loc href="#terms-validation-processing">validation processing</loc> on a TTML <loc href="#terms-document-instance">document instance</loc> prior to performing
 other types of processing, e.g., presentation or transformation processing.</p>
-<p>If this parameter's value is <code>optional</code>, then, a <loc href="#terms-validating-content-processor">validating content processor</loc>
+<p>If this parameter&apos;s value is <code>optional</code>, then, a <loc href="#terms-validating-content-processor">validating content processor</loc>
 may, but need not, perform <loc href="#terms-validation-processing">validation processing</loc> on a TTML <loc href="#terms-document-instance">document instance</loc> prior to performing
 other types of processing, e.g., presentation or transformation processing.</p>
-<p>If this parameter's value is <code>prohibited</code>, then, a <loc href="#terms-validating-content-processor">validating content processor</loc>
+<p>If this parameter&apos;s value is <code>prohibited</code>, then, a <loc href="#terms-validating-content-processor">validating content processor</loc>
 must not perform <loc href="#terms-validation-processing">validation processing</loc> on a TTML <loc href="#terms-document-instance">document instance</loc> prior to performing
 other types of processing, e.g., presentation or transformation processing, unless the end-user or application overrides this prohibition.</p>
 <p>If <loc href="#terms-validation-processing">validation processing</loc> is performed on a TTML <loc href="#terms-document-instance">document instance</loc> and validation fails, then the computed value of
@@ -5256,15 +5256,15 @@ ttp:validationAction
 </tr>
 </tbody>
 </table>
-<p>If this parameter's value is <code>abort</code>, then, unless abort processing is overridden by the end-user or application,
+<p>If this parameter&apos;s value is <code>abort</code>, then, unless abort processing is overridden by the end-user or application,
 a <loc href="#terms-validating-content-processor">validating content processor</loc>
 must abort processing of a TTML <loc href="#terms-document-instance">document instance</loc> when a
 <termref def="defs-validation-error">validation error</termref> exception occurs.</p>
-<p>If this parameter's value is <code>warn</code>, then, a <loc href="#terms-validating-content-processor">validating content processor</loc>
+<p>If this parameter&apos;s value is <code>warn</code>, then, a <loc href="#terms-validating-content-processor">validating content processor</loc>
 should warn the end-user when a <termref def="defs-validation-error">validation error</termref> or
 <termref def="defs-validation-warning">validation warning</termref> exception occurs
 and give the end-user the option to continue or abort processing.</p>
-<p>If this parameter's value is <code>ignore</code>, then, a <loc href="#terms-validating-content-processor">validating content processor</loc>
+<p>If this parameter&apos;s value is <code>ignore</code>, then, a <loc href="#terms-validating-content-processor">validating content processor</loc>
 should not abort and should not warn the end-user when a <loc href="#semantics-validation-state-validation-exception">validation exception</loc>
 occurs.</p>
 <p>If not specified, the value of this parameter is determined as follows:
@@ -5351,7 +5351,7 @@ matches the cell size.</p>
 </note>
 <p>Except where indicated otherwise, when a <loc href="#style-value-length">&lt;length&gt;</loc> expressed in
 cells denotes a dimension parallel to the inline or block progression dimension,
-the cell's dimension in the inline or block progression dimension applies, respectively.</p>
+the cell&apos;s dimension in the inline or block progression dimension applies, respectively.</p>
 <note role="example">
 <p>For example, if padding (on all four edges) is specified as 0.1c, the cell resolution
 is 20 by 10, and the extent of the <loc href="#terms-root-container-region">root container region</loc> is 640 by 480, then, assuming top to bottom,
@@ -5388,7 +5388,7 @@ ttp:clockMode
 <p>If the time base, defined by <specref
 ref="parameter-attribute-timeBase"/>, is designated as
 <code>clock</code>, then this parameter applies as follows: if the
-parameter's value is <code>local</code>, then time expressions are
+parameter&apos;s value is <code>local</code>, then time expressions are
 interpreted as local wall-clock time (and date) coordinates;
 if <code>utc</code>, then time expressions are
 interpreted as UTC time coordinates
@@ -5469,7 +5469,7 @@ ttp:dropMode
 <p>If the time base, defined by <specref
 ref="parameter-attribute-timeBase"/>, is designated as
 <code>smpte</code>, then this parameter applies as follows: if the
-parameter's value is <code>nonDrop</code>, then, within any given
+parameter&apos;s value is <code>nonDrop</code>, then, within any given
 second of a time expression, frames count from 0 to
 <emph>N&minus;1</emph>, where <emph>N</emph> is the value specified by
 the <att>ttp:frameRate</att> parameter, but while ignoring any value
@@ -5481,7 +5481,7 @@ second of real time during normal (1x speed) forward playback. If the
 equal to 1:1, then a second of a time expression will either be
 shorter or longer than a second of elapsed play in real
 time.</p></note>
-<p>If this parameter's value is <code>dropNTSC</code>, then, within any
+<p>If this parameter&apos;s value is <code>dropNTSC</code>, then, within any
 given second of a time expression except the second <code>00</code>,
 frames count from 0 to <emph>N&minus;1</emph>, where <emph>N</emph> is
 the value specified by the <att>ttp:frameRate</att> parameter, but
@@ -5498,7 +5498,7 @@ in frame count occurs between consecutive frames as shown in the
 following sequence of time expressions: <code>01:08:59:28</code>,
 <code>01:08:59:29</code>, <code>01:09:00:02</code>,
 <code>01:09:00:03</code>.</p></note>
-<p>If this parameter's value is <code>dropPAL</code>, then, within any
+<p>If this parameter&apos;s value is <code>dropPAL</code>, then, within any
 given second of a time expression except the second <code>00</code>,
 frames count from 0 to <emph>N&minus;1</emph>, where <emph>N</emph> is
 the value specified by the <att>ttp:frameRate</att> parameter, but
@@ -5633,7 +5633,7 @@ ttp:markerMode
 <p>If the time base, defined by <specref
 ref="parameter-attribute-timeBase"/>, is designated as
 <code>smpte</code>, then this parameter applies as follows: if the
-parameter's value is <code>continuous</code>, then <bibref ref="smpte12"/> time coordinates
+parameter&apos;s value is <code>continuous</code>, then <bibref ref="smpte12"/> time coordinates
 may be assumed to be linear and either monotonically increasing or
 decreasing; however, if <code>discontinuous</code>, then any assumption
 must not be made regarding linearity or monotonicity of time coordinates.</p>
@@ -5857,7 +5857,7 @@ ttp:timeBase
 </tbody>
 </table>
 <p>If the time base is designated as <code>media</code>, then a time
-expression denotes a coordinate in some media object's time line,
+expression denotes a coordinate in some media object&apos;s time line,
 where the media object may be an external media object with which the
 content of a <loc href="#terms-document-instance">document instance</loc> is to be synchronized, or it may
 be the content of a <loc href="#terms-document-instance">document instance</loc> itself in a case where
@@ -6127,7 +6127,7 @@ a <el>div</el> element is expected to generate
 one or more block
 areas
 that contain zero or more child block areas
-generated by the <el>div</el> element's
+generated by the <el>div</el> element&apos;s
 descendant
 <el>p</el> elements.
 </p>
@@ -6421,7 +6421,7 @@ the insertion of the parsed representation of that element (and its descendants)
 </note>
 <p>The <att>condition</att> attribute may be used with (1) any element in the core vocabulary catalog
 except profile matter, i.e., elements of the <loc href="#element-vocab-type-profile">Profile Module</loc>, and
-(2) any element defined by an <loc href="#terms-extension-module">extension module</loc>, where that element's type
+(2) any element defined by an <loc href="#terms-extension-module">extension module</loc>, where that element&apos;s type
 permits the specification of a <loc href="#content-attribute-condition"><att>condition</att></loc> attribute.</p>
 <p>The value of a <att>condition</att> attribute must adhere to a
 <loc href="#content-value-condition">&lt;condition&gt;</loc> expression
@@ -6430,7 +6430,7 @@ or prior to the time of presentation processing (eager evaluation), where eager 
 from evaluation cannot change or is known to not change during presentation processing.</p>
 <note role="example">
 <p>For example, if a condition expression depends on the value of a <loc href="#content-value-condition-function">condition function</loc>,
-then the condition expression's value may change during presentation processing, in which case eager evaluation cannot be used.</p>
+then the condition expression&apos;s value may change during presentation processing, in which case eager evaluation cannot be used.</p>
 </note>
 <p>For the purpose of presentation processing, if an element specifies a <att>condition</att> attribute, and 
 its <loc href="#content-value-condition">&lt;condition&gt;</loc> expression value evaluates to <code>false</code>,
@@ -6532,9 +6532,9 @@ element and may be specified by an instance of any other element type
 in the core vocabulary catalog except parameter vocabulary.</p>
 <note role="elaboration">
 <p>As specified by <bibref ref="xml10"/>, &sect;2.12, the association of language with an element
-applies to all of that element's descendants unless overridden by a descendant. In other words,
+applies to all of that element&apos;s descendants unless overridden by a descendant. In other words,
 the language that is associated with an element is either specified on the element or is effectively
-inherited from that element's nearest ancestor element.</p>
+inherited from that element&apos;s nearest ancestor element.</p>
 <p>This language association process is based solely on the structure of the
 <loc href="#terms-reduced-xml-infoset">reduced xml infoset</loc> of a <loc href="#terms-document-instance">document instance</loc>
 and occurs prior to performing <loc href="#semantics-region-layout-step-1">intermediate synchronic document construction</loc>.</p>
@@ -6581,9 +6581,9 @@ and these text descriptions are, in turn, associated with <code>en</code> (Engli
 the core vocabulary catalog except parameter vocabulary.</p>
 <note role="elaboration">
 <p>As specified by <bibref ref="xml10"/>, &sect;2.10, the application whitespace signalling that applies to an element
-applies to all of that element's descendants unless overridden by a descendant. In other words,
+applies to all of that element&apos;s descendants unless overridden by a descendant. In other words,
 the application whitespace signaling that applies to an element is either specified on the element or is effectively
-inherited from that element's nearest ancestor element.</p>
+inherited from that element&apos;s nearest ancestor element.</p>
 <p>This application whitespace signalling process is based solely on the structure of the
 <loc href="#terms-reduced-xml-infoset">reduced xml infoset</loc> of a <loc href="#terms-document-instance">document instance</loc>
 and occurs prior to performing <loc href="#semantics-region-layout-step-1">intermediate synchronic document construction</loc>.</p>
@@ -8854,7 +8854,7 @@ defines the background color of a region or an area generated by content flowed 
 <div3 id="style-attribute-backgroundExtent">
 <head>tts:backgroundExtent</head>
 <p>The <att>tts:backgroundExtent</att> attribute may be used to specify the extent (size) of a background image
-independently of the image's intrinsic extent (size).</p>
+independently of the image&apos;s intrinsic extent (size).</p>
 <table id="style-property-details-backgroundExtent" role="common">
 <col css="width: 25%;"/>
 <col/>
@@ -8914,7 +8914,7 @@ and the resulting output value of the target rectangle <emph>TR</emph> is the co
 specifications, then the first specification is the <emph>width</emph> and the second specification is the <emph>height</emph>,
 respectively, of the computed value of this property, in which case both <loc href="#style-value-measure">&lt;measure&gt;</loc> specifications
 must resolve (or be resolvable) to non-negative lengths.</p>
-<p>If the computed value of this style property differs from the image's intrinsic extent (size), then the image raster is scaled independently
+<p>If the computed value of this style property differs from the image&apos;s intrinsic extent (size), then the image raster is scaled independently
 in each dimension to match the computed extent value.</p>
 <p>If a computed value of the property associated with this attribute is not supported,
 then a <loc href="#terms-presentation-processor">presentation processor</loc> must use the closest supported value.</p>
@@ -9313,7 +9313,7 @@ defines whether and how a background image is repeated (tiled) into a region or 
 <p>The <att>tts:border</att> attribute is used to specify a style property that
 defines the border of a region or an area generated by content flowed into a region.</p>
 <note role="clarification">
-<p>When applied to a region, a border is applied as an inset to a region's extent, which is to say, the content rectangle of a region area is reduced by
+<p>When applied to a region, a border is applied as an inset to a region&apos;s extent, which is to say, the content rectangle of a region area is reduced by
 the presence of a border applied to the region.</p>
 </note>
 <table id="style-property-details-border" role="common">
@@ -9376,7 +9376,7 @@ then the border style must be interpreted as if a style of
 then a <loc href="#terms-presentation-processor">presentation processor</loc> must use the value <code>solid</code>.</p>
 <p>If no border color is specified in the value of the <att>tts:border</att> property,
 then the border color must be interpreted as if a color equal
-to the computed value of the element's <code>tts:color</code> style property were specified.</p>
+to the computed value of the element&apos;s <code>tts:color</code> style property were specified.</p>
 <p>If no border radii is specified in the value of the <att>tts:border</att> property,
 then the border radii must be interpreted as if a radii of
 <code>0</code> were specified.</p>
@@ -9513,7 +9513,7 @@ and the computed value of the <att>tts:display</att> property that applies to th
 then the semantics of <att>tts:bpd</att> only apply when computing the block progression dimension of any applicable background color or image;
 however, the dimensions of the content rectangles of the generated areas are not changed.</p>
 <p>If a percentage value is used in a <loc href="#style-value-length">&lt;length&gt;</loc> expression of this attribute,
-it is resolved with respect to the applicable <loc href="#terms-absolute-dimension">absolute dimension</loc> of the generated area's containing area
+it is resolved with respect to the applicable <loc href="#terms-absolute-dimension">absolute dimension</loc> of the generated area&apos;s containing area
 (the nearest ancestor area).</p>
 <note role="clarification">
   <p>A <loc href="#style-value-length">&lt;length&gt;</loc> expression used with this attribute is associated with
@@ -10095,7 +10095,7 @@ of a <loc href="#terms-content-region">content region</loc>;</p></item>
 of an image, overriding its intrinsic extent.</p></item>
 </olist>
 <note role="clarification">
-<p>If a border and (or) padding are applied to a region, then the region's extent includes that border and padding,
+<p>If a border and (or) padding are applied to a region, then the region&apos;s extent includes that border and padding,
 i.e., border and padding are both applied as insets, and, therefore, are interior to the extent of the region.</p>
 </note>
 <table id="style-property-details-extent" role="common">
@@ -10161,7 +10161,7 @@ of the associated <loc href="#terms-content-region">content region</loc>.</p>
   <item><p>if the property applies to a <loc href="#layout-vocabulary-region"><el>region</el></loc> element, either directly or indirectly, then <code>auto</code> is interpreted as if
   the value "<code>100%</code> <code>100%</code>" were specified;</p></item>
   <item><p>if the property applies to an <loc href="#embedded-content-vocabulary-image"><el>image</el></loc> element, then <code>auto</code>
-  is interpreted as if a value equal to the image's intrinsic extent were specified using two pixel-based <loc href="#style-value-length">&lt;length&gt;</loc> <loc href="#terms-component">components</loc>, for example, "<code>200px</code> <code>100px</code>".</p></item>
+  is interpreted as if a value equal to the image&apos;s intrinsic extent were specified using two pixel-based <loc href="#style-value-length">&lt;length&gt;</loc> <loc href="#terms-component">components</loc>, for example, "<code>200px</code> <code>100px</code>".</p></item>
 </olist>
 <note role="clarification"><p>This attribute permits a value consisting of a single keyword <code>"auto"</code> and
 another value consisting of two keywords <code>"auto auto"</code>. These two different values have distinct meanings and are not equivalent.
@@ -10176,7 +10176,7 @@ In particular, the single keyword value <code>"auto"</code> has the semantics de
   then the computed value is determined by performing the
   <loc href="#semantics-style-procedures-contain"><phrase role="strong">[compute containment scaling]</phrase></loc> procedure,
   where the target rectangle <emph>TR</emph> is initialized to the
-  <loc href="#terms-intrinsic-block-content-extent">intrinsic block content extent</loc> of the region's content,
+  <loc href="#terms-intrinsic-block-content-extent">intrinsic block content extent</loc> of the region&apos;s content,
   the reference rectangle <emph>RR</emph> is set to the extent of the <loc href="#terms-root-container-region">root container region</loc>,
   and the resulting output value of the target rectangle <emph>TR</emph> is the computed value;</p></item>
   <item><p>if the property applies to an <loc href="#embedded-content-vocabulary-image"><el>image</el></loc> element,
@@ -10194,7 +10194,7 @@ In particular, the single keyword value <code>"auto"</code> has the semantics de
   then the computed value is determined by performing the
   <loc href="#semantics-style-procedures-cover"><phrase role="strong">[compute cover scaling]</phrase></loc> procedure,
   where the target rectangle <emph>TR</emph> is initialized to the
-  <loc href="#terms-intrinsic-block-content-extent">intrinsic block content extent</loc> of the region's content,
+  <loc href="#terms-intrinsic-block-content-extent">intrinsic block content extent</loc> of the region&apos;s content,
   the reference rectangle <emph>RR</emph> is set to the extent of the <loc href="#terms-root-container-region">root container region</loc>,
   and the resulting output value of the target rectangle <emph>TR</emph> is the computed value;</p></item>
   <item><p>if the property applies to an <loc href="#embedded-content-vocabulary-image"><el>image</el></loc> element,
@@ -10663,7 +10663,7 @@ generated by content flowed into a region.</p>
 <tr>
 <td><emph>Percentages:</emph></td>
 <td>if not <loc href="#layout-vocabulary-region"><el>region</el></loc> element,
-then relative to nearest ancestor <loc href="#terms-styled-element">styled element's</loc> computed font size; otherwise, relative to the
+then relative to nearest ancestor <loc href="#terms-styled-element">styled element&apos;s</loc> computed font size; otherwise, relative to the
 <loc href="#terms-computed-cell-size">computed cell size</loc></td>
 </tr>
 <tr>
@@ -10677,14 +10677,14 @@ then relative to nearest ancestor <loc href="#terms-styled-element">styled eleme
 </tbody>
 </table>
 <p>If a single <loc href="#style-value-length">&lt;length&gt;</loc> value is specified, then this length 
-equally determines the horizontal and vertical size of a glyph's EM square;
+equally determines the horizontal and vertical size of a glyph&apos;s EM square;
 if two <loc href="#style-value-length">&lt;length&gt;</loc> values are specified, then the first determines the horizontal
 size and the second determines the vertical size.</p>
 <p>If horizontal and vertical sizes are expressed independently, then the
 units of the <loc href="#style-value-length">&lt;length&gt;</loc> values must be the same.</p>
 <note role="clarification">
-<p>A glyph's EM square is conventionally defined as the EM square of the font that contains the glyph. That is,
-glyphs do not have an EM square that is distinct from their font's EM square.</p>
+<p>A glyph&apos;s EM square is conventionally defined as the EM square of the font that contains the glyph. That is,
+glyphs do not have an EM square that is distinct from their font&apos;s EM square.</p>
 </note>
 <p>Relative <loc href="#style-value-length">&lt;length&gt;</loc> values
 that appear in this attribute, i.e., values expressed in percentage (<code>%</code>), cell (<code>c</code>), or EM (<code>em</code>) units,
@@ -11132,7 +11132,7 @@ and the computed value of the <att>tts:display</att> property that applies to th
 then the semantics of <att>tts:ipd</att> only apply when computing the inline progression dimension of any applicable background color or image;
 however, the dimensions of the content rectangles of the generated areas are not changed.</p>
 <p>If a percentage value is used in a <loc href="#style-value-length">&lt;length&gt;</loc> expression of this attribute,
-it is resolved with respect to the applicable <loc href="#terms-absolute-dimension">absolute dimension</loc> of the generated area's containing area
+it is resolved with respect to the applicable <loc href="#terms-absolute-dimension">absolute dimension</loc> of the generated area&apos;s containing area
 (the nearest ancestor area).</p>
 <note role="clarification">
   <p>A <loc href="#style-value-length">&lt;length&gt;</loc> expression used with this attribute is associated with
@@ -11294,7 +11294,7 @@ horizontal writing modes, but is the horizontal axis in vertical writing modes.<
 </tr>
 <tr>
 <td><emph>Percentages:</emph></td>
-<td>relative to this element's font size</td>
+<td>relative to this element&apos;s font size</td>
 </tr>
 <tr>
 <td><emph>Animatable:</emph></td>
@@ -11893,11 +11893,11 @@ not be clipped outside of the affected region.
 If the value is <code>hidden</code>, then content should
 be clipped outside of the affected region.</p>
 <note role="clarification">
-<p>Marks produced by content associated with a region's content rectangle may be rendered outside that
-content rectangle, thus intersecting with the region's padding and border rectangles, without any affect from
+<p>Marks produced by content associated with a region&apos;s content rectangle may be rendered outside that
+content rectangle, thus intersecting with the region&apos;s padding and border rectangles, without any affect from
 the <att>tts:overflow</att> attribute. Such marks only become a candidate for region overflow when they would
-extend outside the region's extent which is coincident with the region's border rectangle, which contains the
-region's padding rectangle, which contains the region's content rectangle.</p>
+extend outside the region&apos;s extent which is coincident with the region&apos;s border rectangle, which contains the
+region&apos;s padding rectangle, which contains the region&apos;s content rectangle.</p>
 </note>
 <note role="explanation">
 <p>Unless a manual line break element <el>br</el> is used by the content author,
@@ -12014,7 +12014,7 @@ at non-terminal, i.e., non-first and non-last, inline area boundaries, as define
 it is resolved as follows:</p>
 <ulist>
   <item><p>when applied to a <loc href="#layout-vocabulary-region"><el>region</el></loc> element, the percentage is relative to the applicable
-  <loc href="#terms-absolute-dimension">absolute dimension</loc> of the region's resolved extent, unless that dimension is dependent on the
+  <loc href="#terms-absolute-dimension">absolute dimension</loc> of the region&apos;s resolved extent, unless that dimension is dependent on the
   size of the content of the region, in which case the percentage resolves to the corresponding <loc href="#terms-component">component</loc> of the applicable initial value;</p></item>
   <item><p>when applied to all other elements, the percentage is relative to the corresponding
   <loc href="#terms-absolute-dimension">absolute dimension</loc> of the nearest ancestor area, unless that dimension is dependent on the
@@ -12078,9 +12078,9 @@ applies to the area is rendered into the padded portion of the area.</p>
 <p>The above example depicts how padding is applied as an inset to a region area. In particular,
 <code>10px</code> of padding is applied to the before (top) and after (bottom) edges, and
 <code>40px</code> of padding is applied at the start (left) and end (right) edges. Subtracting
-these from the extent of the region area results in the region's content rectangle having <code>366px</code> width
-and <code>84px</code> height. The black background color of the region appears in the region's padding rectangle
-while the red background color of the paragraph appears in the region's content rectangle.</p>
+these from the extent of the region area results in the region&apos;s content rectangle having <code>366px</code> width
+and <code>84px</code> height. The black background color of the region appears in the region&apos;s padding rectangle
+while the red background color of the paragraph appears in the region&apos;s content rectangle.</p>
 </note>
 <table id="style-attribute-padding-example-2" role="example">
     <caption>Example Fragment &ndash; Padding on span</caption>
@@ -12716,7 +12716,7 @@ children of the <loc href="#terms-ruby-container-span">ruby container span</loc>
 <p>When this attribute is specified on a
 <loc href="#content-vocabulary-span"><el>span</el></loc> element for which the computed value of <loc href="#style-attribute-ruby">tts:ruby</loc> is
 <code>container</code>, then the ruby alignment semantics of the associated style property apply collectively to the inline areas generated by
-the container's constituent <termref def="defs-ruby-container">ruby containers</termref> and ruby content.</p>
+the container&apos;s constituent <termref def="defs-ruby-container">ruby containers</termref> and ruby content.</p>
 <note role="elaboration"><p>A consequence of applying ruby alignment to a <termref def="defs-ruby-container">ruby container</termref> as a whole is that the ruby alignment that applies to
 the container and its constituents is uniform (unvarying).</p></note>
 <p>Let <emph>I<sub>R</sub></emph> and <emph>I<sub>B</sub></emph> be, respectively, the inline areas generated by (1) a <termref def="defs-ruby-text-container">ruby text container</termref> or
@@ -12900,7 +12900,7 @@ then a <loc href="#terms-presentation-processor">presentation processor</loc> mu
 <p>When employing the Mongolian script set in vertical left-to-right lines, it may be desirable that the initial value assigned
 to ruby position be <code>after</code> instead of <code>outside</code>, which is resolved to <code>before</code> for all non-final lines. In
 this case, an author may redefine the default initial value for this attribute by including an element
-<code>&lt;initial tts:rubyPosition="after"/&gt;</code> in a document's <code>styling</code> element.</p>
+<code>&lt;initial tts:rubyPosition="after"/&gt;</code> in a document&apos;s <code>styling</code> element.</p>
 </note>
 <p>The <att>tts:rubyPosition</att> style is illustrated by the following example, which illustrates
 how the resolution of ruby position depends upon writing mode. Note that the example uses <emph>mono ruby</emph> as defined in <bibref ref="jlreq"/>.</p>
@@ -13021,7 +13021,7 @@ placement regardless of the presence or absence of ruby text annotations.</p>
 </tr>
 <tr>
 <td><emph>Percentages:</emph></td>
-<td>relative to this element's font size</td>
+<td>relative to this element&apos;s font size</td>
 </tr>
 <tr>
 <td><emph>Animatable:</emph></td>
@@ -13245,9 +13245,9 @@ if either apply to the region.</p></note>
 <p>If a region is not <loc href="#terms-temporally-active">temporally active</loc>, then its background is not rendered; however, if it is
 <loc href="#terms-temporally-active">temporally active</loc>, then</p>
 <olist>
-  <item><p>if the value of this attribute is <code>whenActive</code>, then the region's background is rendered only when
+  <item><p>if the value of this attribute is <code>whenActive</code>, then the region&apos;s background is rendered only when
   content is selected into the region, where that content is also <loc href="#terms-temporally-active">temporally active</loc>;</p></item>
-  <item><p>otherwise, if the value of this attribute is <code>always</code>, then the region's background is rendered irrespective of
+  <item><p>otherwise, if the value of this attribute is <code>always</code>, then the region&apos;s background is rendered irrespective of
   whether content is selected into the region.</p></item>
 </olist>
 <p>If a computed value of the property associated with this attribute is not supported,
@@ -13629,7 +13629,7 @@ then the emphasis position must be interpreted as if a position of <code>outside
 <p>When employing the Mongolian script set in vertical left-to-right lines, it may be desirable that the initial value assigned
 to emphasis position be <code>after</code> instead of <code>outside</code>, which is resolved to <code>before</code> for all non-final lines. In
 this case, an author may redefine the default initial value for this attribute by including an element
-<code>&lt;initial tts:textEmphasis="none transparent after"/&gt;</code> in a document's <code>styling</code> element.</p>
+<code>&lt;initial tts:textEmphasis="none transparent after"/&gt;</code> in a document&apos;s <code>styling</code> element.</p>
 </note>
 <p>The <att>tts:textEmphasis</att> style is illustrated by the following example.</p>
 <table id="text-emphasis-example-1" role="example">
@@ -13725,7 +13725,7 @@ and where <emph>upright</emph> means not rotated.</p>
 <note role="clarification">
 <p>According to <bibref ref="utr50"/>, visual rotation of a <loc href="#terms-glyph-area">glyph areas</loc> may occur through either the substitution
  of a rotated <loc href="#terms-glyph-area">glyph areas</loc> or by performing an affine rotation transformation on the 
- <loc href="#terms-glyph-area">glyph areas</loc>'s outline (or raster image),
+ <loc href="#terms-glyph-area">glyph areas</loc>&apos;s outline (or raster image),
 where the determination of which of these applies depends on the specific font used during presentation processing.</p>
 </note>
 <p>If the value of this attribute is <code>sideways</code>, then all <loc href="#terms-glyph-area">glyph areas</loc>
@@ -13801,7 +13801,7 @@ by content flowed into a region.</p>
 </tr>
 <tr>
 <td><emph>Percentages:</emph></td>
-<td>relative to this element's font size</td>
+<td>relative to this element&apos;s font size</td>
 </tr>
 <tr>
 <td><emph>Animatable:</emph></td>
@@ -13827,7 +13827,7 @@ then the computed value of <code>0px</code> applies.</p>
 <note role="elaboration">
 <p>When a <loc href="#style-value-length">&lt;length&gt;</loc> expressed in
 cells is used in a <att>tts:textOutline</att> value,
-the cell's height applies.
+the cell&apos;s height applies.
 For example, if text outline thickness is specified as 0.1c, the cell resolution
 is 20 by 10, and the extent of the <loc href="#terms-root-container-region">root container region</loc> is 640 by 480, then the
 outline thickness will be a nominal 480 / 10 * 0.1 pixels, i.e., 4.8px,
@@ -13907,7 +13907,7 @@ by content flowed into a region.</p>
 </tr>
 <tr>
 <td><emph>Percentages:</emph></td>
-<td>relative to this element's font size</td>
+<td>relative to this element&apos;s font size</td>
 </tr>
 <tr>
 <td><emph>Animatable:</emph></td>
@@ -14228,7 +14228,7 @@ then a <loc href="#terms-presentation-processor">presentation processor</loc> mu
 ...
 &lt;p&gt;
   I'll tell thee everything I can:&lt;br/&gt;
-  There's little to relate.&lt;br/&gt;
+  There&apos;s little to relate.&lt;br/&gt;
   I saw an aged aged man,&lt;br/&gt;
   A-sitting on a gate.
 &lt;/p&gt;
@@ -14556,9 +14556,9 @@ that defined by <bibref ref="webaudio"/>, &sect;2.7, where the element on which 
 is specified generates a <code>GainNode</code> in the audio graph, whose <code>gain</code>
 attribute has the same computed value, and whose input for a 
 <loc href="#terms-content-element">content element</loc> that is not an <loc href="#terms-audio-generating-element">audio generating element</loc>
-is the sum of the audio output of this element's parent element and the combined (linearly summed) audio
+is the sum of the audio output of this element&apos;s parent element and the combined (linearly summed) audio
 output of all child audio generating elements; otherwise, i.e., for an audio generating element, the input
-is the element's generated audio.</p>
+is the element&apos;s generated audio.</p>
 </note>
 </div3>
 <div3 id="audio-style-attribute-pan">
@@ -14641,9 +14641,9 @@ that defined by <bibref ref="webaudio"/>, &sect;2.21, where the element on which
 is specified generates a <code>StereoPannerNode</code> in the audio graph, whose <code>pan</code>
 attribute has the same computed value, and whose input for a 
 <loc href="#terms-content-element">content element</loc> that is not an <loc href="#terms-audio-generating-element">audio generating element</loc>
-is the sum of the audio output of this element's parent element and the combined (linearly summed) audio
+is the sum of the audio output of this element&apos;s parent element and the combined (linearly summed) audio
 output of all child audio generating elements; otherwise, i.e., for an audio generating element, the input
-is the element's generated audio.</p>
+is the element&apos;s generated audio.</p>
 </note>
 </div3>
 <div3 id="audio-style-attribute-pitch">
@@ -15632,19 +15632,19 @@ and <code>auto</code>.</p>
 <gitem>
 <label><code>maxContent</code></label>
 <def>
-<p>For <emph>ipd</emph>, the maximum numeric value that encloses all of the element's content such that lines are broken only at
-hard, i.e., mandatory, break points, even if that means overflowing the parent's <emph>ipd</emph>.</p>
-<p>For <emph>bpd</emph>, the maximum numeric value that encloses all of the element's content such that lines are broken at
+<p>For <emph>ipd</emph>, the maximum numeric value that encloses all of the element&apos;s content such that lines are broken only at
+hard, i.e., mandatory, break points, even if that means overflowing the parent&apos;s <emph>ipd</emph>.</p>
+<p>For <emph>bpd</emph>, the maximum numeric value that encloses all of the element&apos;s content such that lines are broken at
 all possible line break positions, i.e., both hard (mandatory) and soft (optional) break points.</p>
 </def>
 </gitem>
 <gitem>
 <label><code>minContent</code></label>
 <def>
-<p>For <emph>ipd</emph>, the minimum numeric value that encloses all of the element's content such that lines are broken at
+<p>For <emph>ipd</emph>, the minimum numeric value that encloses all of the element&apos;s content such that lines are broken at
 all possible line break positions, i.e., both hard (mandatory) and soft (optional) break points.</p>
-<p>For <emph>bpd</emph>, the minimum numeric value that encloses all of the element's content such that lines are broken only at
-hard, i.e., mandatory, break points, even if that means overflowing the parent's <emph>ipd</emph>.</p>
+<p>For <emph>bpd</emph>, the minimum numeric value that encloses all of the element&apos;s content such that lines are broken only at
+hard, i.e., mandatory, break points, even if that means overflowing the parent&apos;s <emph>ipd</emph>.</p>
 </def>
 </gitem>
 <gitem>
@@ -15784,7 +15784,7 @@ are considered to be equal to the numeric value zero (0).</p>
 </div3>
 <div3 id="style-value-padding">
 <head>&lt;padding&gt;</head>
-<p>A &lt;padding&gt; expression specifies the insets that apply to an area's padding rectangle.</p>
+<p>A &lt;padding&gt; expression specifies the insets that apply to an area&apos;s padding rectangle.</p>
 <table id="padding-style-expression-syntax" role="syntax">
 <caption>Syntax Representation &ndash; &lt;padding&gt;</caption>
 <tbody>
@@ -16299,7 +16299,7 @@ present, then the computed value of the <att>tts:color</att> property applies.</
 <note role="elaboration">
 <p>When a <loc href="#style-value-length">&lt;length&gt;</loc> expressed in
 cells is used in a <att>tts:textShadow</att> value,
-the cell's dimension in the block progression dimension applies.
+the cell&apos;s dimension in the block progression dimension applies.
 For example, if text shadow thickness is specified as 0.1c, the cell resolution
 is 20 by 10, and the extent of the <loc href="#terms-root-container-region">root container region</loc> is 640 by 480, then the
 shadow thickness will be a nominal 480 / 10 * 0.1 pixels, i.e., 4.8px,
@@ -16622,7 +16622,7 @@ inheritable.</p>
 <p>If a style property is determined to require inheritance, then the inherited value must
 be the value of the same named style property in the computed
 style set of the
-element's nearest ancestor element that defines the property
+element&apos;s nearest ancestor element that defines the property
 within the applicable intermediate synchronic document.</p>
 <table id="style-inheritance-example-2" role="example">
 <caption>Example &ndash; Content Style Inheritance</caption>
@@ -17347,10 +17347,10 @@ its content, and (2) to provide a temporal context in which animations of region
 styles may be effected.</p>
 <p>For example, an author may wish to specify an <loc href="#terms-out-of-line-region">out-of-line</loc> <el>region</el> element that is otherwise empty, but
 may have a visible background color to be presented starting at some time and
-continuing over the region's duration.  The simple duration of the region serves
+continuing over the region&apos;s duration.  The simple duration of the region serves
 additionally to scope the presentation effects of content that is targeted to the
 region. An author may also wish to move a region within the <loc href="#terms-root-container-region">root container region</loc>
-or change a region's background color by means of animation effects. In
+or change a region&apos;s background color by means of animation effects. In
 both of these cases, it is necessary to posit an active time interval for a
 region.</p>
 <p>In contrast to <loc href="#terms-out-of-line-region">out-of-line regions</loc>, <loc href="#terms-inline-region">inline regions</loc> are specifically bound to
@@ -17802,9 +17802,9 @@ longer semantically relevant.</p>
 </olist>
 <note role="elaboration">
 <p>In this section, the term <emph>prune</emph>, when used in reference to
-an element, means that the element is to be removed from its parent's children,
+an element, means that the element is to be removed from its parent&apos;s children,
 which, in turn, implies that the descendants of the pruned element will no longer
-be descendants of the element's parent. When <emph>prune</emph> is used in
+be descendants of the element&apos;s parent. When <emph>prune</emph> is used in
 reference to an attribute, it means that attribute is to be removed from its
 associated (owning) <termref def="defs-element-node">element node</termref>.</p>
 </note>
@@ -17942,10 +17942,10 @@ above in <specref ref="definitions"/>.</p>
 <p>map each non-empty <el>region</el> element to an <el>fo:block-container</el>
 element with an <att>absolute-position</att> attribute with value
 <code>absolute</code>, with <att>top</att>, <att>left</att>, <att>bottom</att>, and <att>right</att>
-attributes that express a rectangle equivalent to the region's origin and
+attributes that express a rectangle equivalent to the region&apos;s origin and
 extent (including padding), and with a <att>line-stacking-strategy</att> attribute with value <code>line-height</code>;</p>
 <note role="clarification">
-<p>The region's extent corresponds with the allocation rectangle of the block area generated by the <code>fo:block-container</code>.</p>
+<p>The region&apos;s extent corresponds with the allocation rectangle of the block area generated by the <code>fo:block-container</code>.</p>
 </note>
 <note role="clarification">
 <p>When mapping a <el>region</el> element to <el>fo:block-container</el>, it may
@@ -18252,7 +18252,7 @@ the rendering model specified by <bibref ref="xslfo11"/>, &sect;4.9; in addition
 <note role="clarification">
   <p>The marks produced by an <loc href="#embedded-content-vocabulary-image"><el>image</el></loc> element referenced by a
   <loc href="#style-attribute-backgroundImage"><att>tts:backgroundImage</att></loc> attribute are not included in the intrinsic
-  marks of a block area or an inline area, i.e., they are part of an area's background marks.</p>
+  marks of a block area or an inline area, i.e., they are part of an area&apos;s background marks.</p>
 </note>
 </div4> <!-- semantics-rendering-model-painting-order -->
 </div3> <!-- semantics-rendering-model -->
@@ -18326,7 +18326,7 @@ the <att>dur</att> attribute is permitted to be zero (<code>0s</code>).</p>
 this specification, the active duration of an element that specifies both
 <att>end</att> and <att>dur</att> attributes is equal to the lesser of the value of
 the <att>dur</att> attribute and the difference between the value of the
-<att>end</att> attribute and the element's begin time.</p>
+<att>end</att> attribute and the element&apos;s begin time.</p>
 </note>
 </div3>
 <div3 id="timing-attribute-end">
@@ -18545,9 +18545,9 @@ constraints:</p>
 <ulist>
 <item>
 <p>The implicit duration of an <loc href="#terms-anonymous-span">anonymous span</loc> is defined as follows: if
-the <loc href="#terms-anonymous-span">anonymous span's</loc> parent time container is a parallel time container, then
+the <loc href="#terms-anonymous-span">anonymous span&apos;s</loc> parent time container is a parallel time container, then
 the implicit duration is equivalent to the <code>indefinite</code>
-duration value as defined by <bibref ref="smil3"/>; if the <loc href="#terms-anonymous-span">anonymous span's</loc>
+duration value as defined by <bibref ref="smil3"/>; if the <loc href="#terms-anonymous-span">anonymous span&apos;s</loc>
 parent time container is a sequential time container, then the implicit duration
 is equivalent to zero.</p>
 </item>
@@ -18960,7 +18960,7 @@ In <bibref ref="svg11"/>, this would require the use of multiple <el>set</el> el
 enumerated above are defined to be those specified by <bibref ref="svg11"/>, &sect;19.2.13:</p>
 <olist>
 <item><p>The attributes targeted by a <el>set</el> element and the discrete values to be applied to these attributes are
-specified by direct use of <loc href="#terms-styling-attribute">styling attributes</loc> (as opposed to using SVG's
+specified by direct use of <loc href="#terms-styling-attribute">styling attributes</loc> (as opposed to using SVG&apos;s
 <att>attributeName</att> and <att>to</att> attributes).</p>
 <note role="example">
 <p>For example, specifying <code>tts:color="red"</code> is
@@ -19295,7 +19295,7 @@ style, layout, timing, and even metadata itself, where the information
 represented by metadata takes one of two forms: (1) metadata defined by this
 specification for standardized use in a <loc href="#terms-document-instance">document instance</loc>, and (2) arbitrary
 metadata defined outside of the scope of this specification, whose use and
-semantics depend entirely upon an application's use of TTML Content.</p>
+semantics depend entirely upon an application&apos;s use of TTML Content.</p>
 <p>This specification does not define any presentation semantics for metadata; therefore, a conformant
 <loc href="#terms-presentation-processor">presentation processor</loc> may ignore all metadata matter.</p>
 <note role="clarification">
@@ -19610,7 +19610,7 @@ where the latter is linked to the former by means of the a
 <el>p</el> element) to the character agent associated with
 (responsible for producing) that content. Note that in this example
 the <el>ttm:agent</el> metadata items are specified as immediate
-children of the document's <el>head</el> element rather than being
+children of the document&apos;s <el>head</el> element rather than being
 placed in a container <el>metadata</el> element.</p>
 </note>
 </div3>
@@ -19707,7 +19707,7 @@ the definition of a specific named item may further constrain the context of use
 </note>
 <p>The value of a named metadata item is
 (1) empty if the element has no child text or <termref def="defs-element-node">element node</termref>s,
-(2) the character content of the <el>ttm:item</el> element when that element's children consists solely of <termref def="defs-text-node">text node</termref>s, or
+(2) the character content of the <el>ttm:item</el> element when that element&apos;s children consists solely of <termref def="defs-text-node">text node</termref>s, or
 (3) a collection of named metadata sub-items.</p>
 <note role="elaboration">
 <p>The definition of a particular named item will typically constrain the set of permitted values. Furthermore, it may
@@ -19716,7 +19716,7 @@ specify that a particular value is implied in the absence of a specified value.<
 <note role="elaboration">
 <p>When the value of a named metadata item consists of natural language text, the
 <loc href="#content-attribute-xml-lang"><att>xml:lang</att></loc> attribute may be directly
-specified on the metadata item element or indirectly inherited from that element's nearest ancestor
+specified on the metadata item element or indirectly inherited from that element&apos;s nearest ancestor
 in order to identify the language that applies to the named metadata item value.</p>
 </note>
 <p>The use of a named metadata item is illustrated by the following example, which shows the use of a named metadata item
@@ -19979,7 +19979,7 @@ provide a text equivalent or summary for some related image content.</p>
 <note role="elaboration"><p>This text equivalent may be used to support indexing of the content and also facilitate
 quality checking of a document during authoring.</p></note>
 <note role="elaboration"><p>In contrast to <bibref ref="html52"/>, the text content of this named
-metadata item is not intended to be presented in place of a referring element if the element's primary (as opposed to alternate)
+metadata item is not intended to be presented in place of a referring element if the element&apos;s primary (as opposed to alternate)
 content cannot be presented; however, this alternate text content can be used by assistive technologies.</p></note>
 </def>
 </gitem>
@@ -25781,7 +25781,7 @@ followed by exactly one <loc href="#document-structure-vocabulary-body"><el>body
 <p>If the computed style set of the region represented by the <el>isd:region</el> element is not the
 set of initial style values that apply to <loc href="#layout-vocabulary-region"><el>region</el></loc>, then a
 <att>style</att> attribute must be specified which references an <loc href="#isd-vocabulary-css"><el>isd:css</el></loc> element that specifies the
-region's computed style set.</p>
+region&apos;s computed style set.</p>
 <p>The following constraints apply to the <loc href="#document-structure-vocabulary-body"><el>body</el></loc> element
 and its descendant elements:</p>
 <ulist>
@@ -25800,7 +25800,7 @@ and its descendant elements:</p>
 each of its descendant <loc href="#terms-content-element">content elements</loc> <emph>C</emph>, if the computed style set of <emph>B</emph> or each <emph>C</emph> is
 not equal to the computed style set of its parent element, then that element, <emph>B</emph> or <emph>C</emph>, must specify a <att>style</att>
 attribute that references an <loc href="#isd-vocabulary-css"><el>isd:css</el></loc> element that specifies the
-element's computed style set.</p>
+element&apos;s computed style set.</p>
 </div3>
 </div2>
 <div2 id="isd-parameter-attribute-set">
@@ -27138,13 +27138,13 @@ the details column includes "-excl", which denotes that the
 <code>excl</code> value that is specified for use with the
 <att>timeContainer</att> model attribute is not specified for use with the
 corresponding TTML attribute; similarly, a "+<emph>value</emph>"
-in the details column indicates that the attribute's values have been
+in the details column indicates that the attribute&apos;s values have been
 extended to include <emph>value</emph>.</p>
 <p>Only those attributes that are specified for use on more than one TTML
 element type are listed below. Those per-element namespace attributes
 that are uniquely defined for a specific TTML element type are not
 listed below, but are considered to be part of the specific element
-type's derivation described in <specref
+type&apos;s derivation described in <specref
 ref="element-vocab-derivation-table"/>
 above.</p>
 <p>Style attribute derivations are listed separately below.</p>
@@ -27996,7 +27996,7 @@ disparity shift value defined in <bibref ref="DVBSS"/>.</p></note>
 <item><p><loc href="#style-attribute-fontSize-special-semantics">Special inheritance semantics</loc> apply.</p></item>
 <item><p>Restricts size to length specification which can be a percentage;</p></item>
 <item><p>adds optional second length (or percentage) for
-specifying separate horizontal and vertical scaling of glyph's EM
+specifying separate horizontal and vertical scaling of glyph&apos;s EM
 square;</p></item>
 <item><p>The addition of a second length <loc href="#terms-component">component</loc> to permit specifying font
 width and height independently is an extension introduced by TTML.</p></item>
@@ -28006,7 +28006,7 @@ width and height independently is an extension introduced by TTML.</p></item>
 <item><p><loc href="#style-attribute-fontSize-special-semantics">Special inheritance semantics</loc> apply.</p></item>
 <item><p>Restricts size to length specification which can be a percentage;</p></item>
 <item><p>adds optional second length (or percentage) for
-specifying separate horizontal and vertical scaling of glyph's EM
+specifying separate horizontal and vertical scaling of glyph&apos;s EM
 square;</p></item>
 <item><p>The addition of a second length <loc href="#terms-component">component</loc> to permit specifying font
 width and height independently is an extension introduced by TTML.</p></item>
@@ -29058,7 +29058,7 @@ clause</xspecref></td>
 <td><phrase role="strong">Notes</phrase></td>
 </tr>
 <tr>
-<td><xspecref href="http://www.w3.org/TR/2005/REC-qaframe-spec-20050817/#conformance-model-gp">Good Practice 01: Define the specification's conformance model in the conformance clause.</xspecref></td>
+<td><xspecref href="http://www.w3.org/TR/2005/REC-qaframe-spec-20050817/#conformance-model-gp">Good Practice 01: Define the specification&apos;s conformance model in the conformance clause.</xspecref></td>
 <td><loc href="#conformance">YES</loc></td>
 <td/>
 <td/>
@@ -29279,9 +29279,9 @@ any controls designed to allow or restrict access to such resources are also out
   <loc href="https://www.w3.org/TR/html52/infrastructure.html#creating-a-potential-cors-request">a potentially CORS-enabled request</loc> as defined 
   in <bibref ref="html52"/> is needed.</p>
 <p>If the fetching of such resources is prevented by the <loc href="#terms-content-processor">content processor</loc>,
-then the entire document or portions of the document may not be processed as intended, and, therefore, some or all of a document's
+then the entire document or portions of the document may not be processed as intended, and, therefore, some or all of a document&apos;s
 content may not be available for presentation processing.</p>
-<p>A user agent that downloads external resources during media playback indicates to the origin server of the resource the progress of the user's 
+<p>A user agent that downloads external resources during media playback indicates to the origin server of the resource the progress of the user&apos;s 
   media consumption. In many cases such media progress information is available to the origin server of the media via other mechanisms, for example 
   by scripting or by monitoring streaming media requests.</p>
 <p>User agents that do not enforce cross origin policies when downloading external resources expose such media progress information and potentially 
@@ -29509,7 +29509,7 @@ presentation order;</p>
 <div2 id="root-fragmentation">
 <head>Root and Branch Fragmentation</head>
 <p>One possible means by which TTML Content may be streamed is to
-partition a <loc href="#terms-document-instance">document instance</loc>'s information set into
+partition a <loc href="#terms-document-instance">document instance</loc>&apos;s information set into
 non-overlapping fragments, where one particular fragment, call it the
 <emph>root fragment</emph>, represents the front matter (head) of the
 <loc href="#terms-document-instance">document instance</loc> as well as its top level structural elements, and
@@ -29541,7 +29541,7 @@ capabilities model.</p>
 <div2 id="temporal-fragmentation">
 <head>Temporal Fragmentation</head>
 <p>Another means by which TTML Content may be streamed is to
-partition a <loc href="#terms-document-instance">document instance</loc>'s information set into
+partition a <loc href="#terms-document-instance">document instance</loc>&apos;s information set into
 temporally bound fragments, each of which is itself a document instance that contains all the
 front matter (head) and content required to present it, where the temporal interval for each
 fragment is constrained, either by the <loc href="#terms-document-interchange-context">document
@@ -29640,7 +29640,7 @@ old paragraph (line) out and a new paragraph (line) in, will be either smooth or
 <head>Paint-On Caption Example</head>
 <p>An example of paint-on captions. Paint-on effects are achieved by using timed <el>span</el> elements in order to expose (paint) inline text units, e.g., words,
 over some time interval. Here, five paragraphs have their individual words sequentially timed in order to paint one new word every second. The end of the active duration of
-each inline element coincides with the end of the <el>div</el> element's parallel time container, so that once a word is painted, it remains in the region (on its rendered line) until the <el>div</el> element's active time interval lapses.</p>
+each inline element coincides with the end of the <el>div</el> element&apos;s parallel time container, so that once a word is painted, it remains in the region (on its rendered line) until the <el>div</el> element&apos;s active time interval lapses.</p>
 <table id="paint-on-example-1-s" role="example">
 <caption>Example &ndash; Paint-On Captions</caption>
 <tbody>


### PR DESCRIPTION
Trivial editorial change only.