### PR TITLE
Clarify undefined semantics for text combine in ruby text (#978).

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -13438,10 +13438,10 @@ If the specified value of this attribute is <code>all</code>, then all affected 
 then a <loc href="#terms-presentation-processor">presentation processor</loc> must use the value <code>none</code>.</p>
 <note role="clarification">
 <p>This version of TTML does not define any semantics for the <att>tts:textCombine</att> attribute
-in the context of <termref def="defs-ruby-text-content">ruby text content</termref>. In particular,
-a conformant <loc href="#terms-presentation-processor">presentation processor</loc>
-may ignore the <att>tts:textCombine</att> attribute in the context of a <termref def="defs-ruby-container">ruby container</termref>;
-that is, it may treat it as if the value <code>none</code> were specified.</p>
+in the context of a <termref def="defs-ruby-container">ruby container</termref>. As a consequence, a content author is advised to
+not expect any specific behavior by a 
+conformant <loc href="#terms-presentation-processor">presentation processor</loc>
+when a <att>tts:textCombine</att> attribute is used in the context of a <termref def="defs-ruby-container">ruby container</termref>.</p>
 </note>
 <p>The <att>tts:textCombine</att> style is illustrated by the following example.</p>
 <table id="text-combine-example" role="example">

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -13437,10 +13437,9 @@ If the specified value of this attribute is <code>all</code>, then all affected 
 <p>If a computed value of the property associated with this attribute is not supported,
 then a <loc href="#terms-presentation-processor">presentation processor</loc> must use the value <code>none</code>.</p>
 <note role="clarification">
-<p>This version of TTML does not define any semantics for the <att>tts:textCombine</att> attribute
-in the context of a <termref def="defs-ruby-container">ruby container</termref>. In particular,
-a conformant <loc href="#terms-presentation-processor">presentation processor</loc> may treat such usage
-as if the value <code>none</code> had been specified.</p>
+<p>A conformant <loc href="#terms-presentation-processor">presentation processor</loc>
+may ignore the <att>tts:textCombine</att> attribute in the context of a <termref def="defs-ruby-container">ruby container</termref>;
+that is, it may treat it as if the value <code>none</code> were specified.</p>
 </note>
 <p>The <att>tts:textCombine</att> style is illustrated by the following example.</p>
 <table id="text-combine-example" role="example">

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -13437,7 +13437,9 @@ If the specified value of this attribute is <code>all</code>, then all affected 
 <p>If a computed value of the property associated with this attribute is not supported,
 then a <loc href="#terms-presentation-processor">presentation processor</loc> must use the value <code>none</code>.</p>
 <note role="clarification">
-<p>A conformant <loc href="#terms-presentation-processor">presentation processor</loc>
+<p>This version of TTML does not define any semantics for the <att>tts:textCombine</att> attribute
+in the context of <termref def="defs-ruby-text-content">ruby text content</termref>. In particular,
+a conformant <loc href="#terms-presentation-processor">presentation processor</loc>
 may ignore the <att>tts:textCombine</att> attribute in the context of a <termref def="defs-ruby-container">ruby container</termref>;
 that is, it may treat it as if the value <code>none</code> were specified.</p>
 </note>

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -13436,6 +13436,12 @@ If the specified value of this attribute is <code>all</code>, then all affected 
 <p>Combination must not cross an element boundary, a bidirectional boundary, or a <loc href="#terms-glyph-area">non-glyph area</loc> boundary.</p>
 <p>If a computed value of the property associated with this attribute is not supported,
 then a <loc href="#terms-presentation-processor">presentation processor</loc> must use the value <code>none</code>.</p>
+<note role="clarification">
+<p>This version of TTML does not define any semantics for the <att>tts:textCombine</att> attribute
+in the context of <termref def="defs-ruby-text-content">ruby text content</termref>. In particular,
+a conformant <loc href="#terms-presentation-processor">presentation processor</loc> may treat such usage
+as if the value <code>none</code> had been specified.</p>
+</note>
 <p>The <att>tts:textCombine</att> style is illustrated by the following example.</p>
 <table id="text-combine-example" role="example">
 <caption>Example Fragment &ndash; Text Combine</caption>

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -13438,7 +13438,7 @@ If the specified value of this attribute is <code>all</code>, then all affected 
 then a <loc href="#terms-presentation-processor">presentation processor</loc> must use the value <code>none</code>.</p>
 <note role="clarification">
 <p>This version of TTML does not define any semantics for the <att>tts:textCombine</att> attribute
-in the context of <termref def="defs-ruby-text-content">ruby text content</termref>. In particular,
+in the context of a <termref def="defs-ruby-container">ruby container</termref>. In particular,
 a conformant <loc href="#terms-presentation-processor">presentation processor</loc> may treat such usage
 as if the value <code>none</code> had been specified.</p>
 </note>


### PR DESCRIPTION
Closes #978.