### PR TITLE
Clarify escape in literal convention (#987).

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -2185,12 +2185,9 @@ SPACE (U+0020), TAB (U+0009), CARRIAGE RETURN (U+000D), or LINE FEED (U+000A),
 which corresponds to production [3] <code>S</code> as defined by <bibref ref="xml10"/>.</p>
 <p>The following conventions are used in the specification of value syntax expressions:</p>
 <ulist>
-  <item><p>a literal term (specified within double or single quotation marks), when present, must appear exactly as specified
-  (excluding the quotation marks themselves and after performing escape processing);</p>
-  <note role="example">
-    <p>For example, the literal <code>&apos;\\&apos;</code> is interpreted as a single backslash, i.e., REVERSE SOLIDUS (U+005C).</p>
-  </note>
-  </item>
+  <item><p>a literal term (specified within quotation marks), when present, must appear exactly  as specified
+  (excluding the quotation marks themselves);</p></item>
+  <item><p>the literal <code>&apos;\\&apos;</code> is interpreted as a single backslash, i.e., REVERSE SOLIDUS (U+005C);</p></item>
   <item><p>concatenated (juxtaposed) terms mean that all terms must appear in the stated order, e.g., <code>a b</code> means that the terms
   <code>a</code> and <code>b</code> are present and the former precedes the latter;</p></item>
   <item><p>a vertical bar (<code>|</code>) separates two or more alternatives, of which exactly one must appear;</p></item>

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -2185,8 +2185,12 @@ SPACE (U+0020), TAB (U+0009), CARRIAGE RETURN (U+000D), or LINE FEED (U+000A),
 which corresponds to production [3] <code>S</code> as defined by <bibref ref="xml10"/>.</p>
 <p>The following conventions are used in the specification of value syntax expressions:</p>
 <ulist>
-  <item><p>a literal term (specified within quotation marks), when present, must appear exactly  as specified
-  (excluding the quotation marks themselves);</p></item>
+  <item><p>a literal term (specified within double or single quotation marks), when present, must appear exactly as specified
+  (excluding the quotation marks themselves and after performing escape processing);</p>
+  <note role="example">
+    <p>For example, the literal <code>&apos;\\&apos;</code> is interpreted as a single backslash, i.e., REVERSE SOLIDUS (U+005C).</p>
+  </note>
+  </item>
   <item><p>concatenated (juxtaposed) terms mean that all terms must appear in the stated order, e.g., <code>a b</code> means that the terms
   <code>a</code> and <code>b</code> are present and the former precedes the latter;</p></item>
   <item><p>a vertical bar (<code>|</code>) separates two or more alternatives, of which exactly one must appear;</p></item>
@@ -15293,7 +15297,7 @@ non-ascii-or-c1
   : [^\0-\237]
 
 escape
-  : "\\" <emph><code>char</code></emph>
+  : &apos;\\&apos; <emph><code>char</code></emph>
 </eg>
 </td>
 </tr>


### PR DESCRIPTION
Closes #987.