### PR TITLE
Clarify semantics of tts:textDecoration value 'none' (#1138).

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -28637,9 +28637,13 @@ details.</td>
 <td><phrase role="strong">Notes</phrase></td>
 <td>Defined to be inheritable with 
 <loc href="#style-attribute-textDecoration-special-semantics">Special inheritance semantics</loc>.</td>
-<td><loc href="#style-attribute-textDecoration-special-semantics">Special inheritance semantics</loc> apply.
-The XSL semantic for
-determining the position of underlines applies.</td>
+<td>Defined to be inheritable with
+<loc href="#style-attribute-textDecoration-special-semantics">Special inheritance semantics</loc>,
+where the XSL semantics for determining the position of underlines apply. Moreover, the semantics of
+the value <code>none</code> is distinct from the same named value in CSS since in TTML it is defined to
+be equivalent to <code>noUnderline</code>, <code>noLineThrough</code>, and <code>noOverline</code>, none
+of which are defined in CSS, and all of which have semantics that cause the removal of inherited decorations
+in TTML, a capability is not (directly) supported by CSS.</td>
 </tr>
 </tbody>
 </table>

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -13519,6 +13519,9 @@ value <loc href="#terms-component">component</loc> syntax defined in <bibref ref
 one or more of the values separated by <code>||</code> may appear in the property
 value in any order, such as <code>"noUnderline overline lineThrough"</code>.</p>
 </note>
+<note role="clarification">
+<p>Specifying the value &quot;<code>none</code>&quot; is equivalent to specifying &quot;<code>noUnderline noLineThrough noOverline</code>&quot;.</p>
+</note>
 <p>The <att>tts:textDecoration</att> style is illustrated by the following example.</p>
 <table id="style-attribute-textDecoration-example-1" role="example">
 <caption>Example Fragment &ndash; Text Decoration</caption>


### PR DESCRIPTION
Closes #1138.