### PR TITLE
Remove applicability of tts:direction on <p>

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -9787,8 +9787,8 @@ background color of the <loc href="#terms-root-container-region">root container 
 </div3>
 <div3 id="style-attribute-direction">
 <head>tts:direction</head>
-<p>The <att>tts:direction</att> attribute is used to specify a style property that, depending on the context of use,
-determines (1) the bidirectional paragraph level, or (2) the directionality of a bidirectional embedding or override,
+<p>The <att>tts:direction</att> attribute is used to specify a style property that 
+determines the directionality of a bidirectional embedding or override,
 about which see <bibref ref="uax9"/>.</p>
 <table id="style-property-details-direction" role="common">
 <col css="width: 25%;"/>
@@ -9810,7 +9810,6 @@ about which see <bibref ref="uax9"/>.</p>
 <tr>
 <td><emph>Applies to:</emph></td>
 <td>
-<loc href="#content-vocabulary-p"><el>p</el></loc>,
 <loc href="#content-vocabulary-span"><el>span</el></loc>
 </td>
 </tr>
@@ -9832,11 +9831,10 @@ about which see <bibref ref="uax9"/>.</p>
 </tr>
 </tbody>
 </table>
-<p>When applied to a <el>p</el> element, the computed value of this property explicitly establishes the
-<emph>paragraph level</emph> as specified by <bibref ref="uax9"/>, &sect;4.3, Higher Level Protocol <phrase role="strong">HL1</phrase>.</p>
-<p>When applied to a <el>span</el> element (or <loc href="#terms-anonymous-span">anonymous span</loc>), the computed value of this property, in combination with the computed value
-of the <att>tts:unicodeBidi</att> style property, determines the directionality of a bidirectional embedding or override as specified by
-<bibref ref="uax9"/>, &sect;4.3, Higher Level Protocol <phrase role="strong">HL3</phrase>.</p>
+<p>The computed value of this property, in combination with the computed value
+of the <att>tts:unicodeBidi</att> style property, determines the directionality of a bidirectional
+embedding or override as specified by <bibref ref="uax9"/>, &sect;4.3, Higher Level Protocol
+<phrase role="strong">HL3</phrase>.</p>
 <p>If a computed value of the property associated with this attribute is not supported,
 then a <loc href="#terms-presentation-processor">presentation processor</loc> must use the value <code>ltr</code>.</p>
 <p>The <att>tts:direction</att> style is illustrated by the following example.</p>
@@ -14176,6 +14174,9 @@ the Unicode bidirectional algorithm.</p>
 </table>
 <p>If a computed value of the property associated with this attribute is not supported,
 then a <loc href="#terms-presentation-processor">presentation processor</loc> must use the value <code>normal</code>.</p>
+<note role="elaboration">
+<p>The values <code>"normal"</code> and <code>"embed"</code> have no effect on <code>p</code>.</p>
+</note>
 <p>The <att>tts:unicodeBidi</att> style is illustrated by the following example.</p>
 <table id="style-attribute-unicodeBidi-example-1" role="example">
 <caption>Example Fragment &ndash; Unicode Bidirectionality</caption>
@@ -14465,6 +14466,9 @@ stacking block and inline areas within a region area.</p>
 </tr>
 </tbody>
 </table>
+<p>
+</p>
+<p>The <loc href="#terms-inline-progression-direction">inline progression direction</loc> determined by the computed value of this property explicitly establishes the <emph>paragraph level</emph> as specified by <bibref ref="uax9"/>, &sect;4.3, Higher Level Protocol <phrase role="strong">HL1</phrase> for all descendent <code>p</code> elements.</p>
 <p>If a computed value of the property associated with this attribute is not supported,
 then a <loc href="#terms-presentation-processor">presentation processor</loc> must use the value <code>lrtb</code>.</p>
 <note role="elaboration">

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -9835,6 +9835,9 @@ about which see <bibref ref="uax9"/>.</p>
 of the <att>tts:unicodeBidi</att> style property, determines the directionality of a bidirectional
 embedding or override as specified by <bibref ref="uax9"/>, &sect;4.3, Higher Level Protocol
 <phrase role="strong">HL3</phrase>.</p>
+<note role="elaboration">
+<p>In earlier editions of this specification, the <att>tts:direction</att> property applied to the <code>p</code> element. This use is now <phrase role="deprecated">deprecated</phrase> in absence of definitive semantics. Authors are encouraged to avoid specifiying <att>tts:direction</att> on a <code>p</code> element, which can result in different rendering results depending on the implementation.</p>
+</note>
 <p>If a computed value of the property associated with this attribute is not supported,
 then a <loc href="#terms-presentation-processor">presentation processor</loc> must use the value <code>ltr</code>.</p>
 <p>The <att>tts:direction</att> style is illustrated by the following example.</p>
@@ -14468,7 +14471,7 @@ stacking block and inline areas within a region area.</p>
 </table>
 <p>
 </p>
-<p>The <loc href="#terms-inline-progression-direction">inline progression direction</loc> determined by the computed value of this property explicitly establishes the <emph>paragraph level</emph> as specified by <bibref ref="uax9"/>, &sect;4.3, Higher Level Protocol <phrase role="strong">HL1</phrase> for all descendent <code>p</code> elements.</p>
+<p>The <loc href="#terms-inline-progression-direction">inline progression direction</loc> determined by the computed value of this property explicitly establishes the <emph>paragraph level</emph> as specified by <bibref ref="uax9"/>, &sect;4.3, Higher Level Protocol <phrase role="strong">HL1</phrase>.</p>
 <p>If a computed value of the property associated with this attribute is not supported,
 then a <loc href="#terms-presentation-processor">presentation processor</loc> must use the value <code>lrtb</code>.</p>
 <note role="elaboration">

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -14153,7 +14153,6 @@ the Unicode bidirectional algorithm.</p>
 <tr>
 <td><emph>Applies to:</emph></td>
 <td>
-<loc href="#content-vocabulary-p"><el>p</el></loc>,
 <loc href="#content-vocabulary-span"><el>span</el></loc>
 </td>
 </tr>
@@ -14178,7 +14177,7 @@ the Unicode bidirectional algorithm.</p>
 <p>If a computed value of the property associated with this attribute is not supported,
 then a <loc href="#terms-presentation-processor">presentation processor</loc> must use the value <code>normal</code>.</p>
 <note role="elaboration">
-<p>The values <code>"normal"</code> and <code>"embed"</code> have no effect on <code>p</code>.</p>
+<p>In earlier editions of this specification, the <att>tts:unicodeBidi</att> property applied to the <code>p</code> element. This use is now <phrase role="deprecated">deprecated</phrase> in absence of definitive semantics. Authors are encouraged to avoid specifiying <att>tts:unicodeBidi</att> on a <code>p</code> element, which can result in different rendering results depending on the implementation.</p>
 </note>
 <p>The <att>tts:unicodeBidi</att> style is illustrated by the following example.</p>
 <table id="style-attribute-unicodeBidi-example-1" role="example">


### PR DESCRIPTION
Closes #1211 
Closes #1213 
Closes #1212

The _paragraph embedding level_ is determined by the `ipd`, instead of being determined by `tts:direction` as applied to `p`. This is compatible with CSS since, in CSS, `direction` sets the _paragraph embedding level_ and the combination of `direction` and `writing-mode` maps to `tts:writingMode`.

The effect of `tts:unicodeBidi` on `p` is clarified to match CSS.

