### PR TITLE
Fix #1232 by clarifying the [resolve timing] procedure

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -25627,7 +25627,7 @@ times in the absence of other external information.</caption>
 <bibref ref="smil3"/>, the implicit duration of the <el>body</el>
 element is identical to its computed duration which,
 in the absence of any external constraints, 
-is also the <loc href="#terms-root-temporal-extent">Root Temporal
+is also the duration of the <loc href="#terms-root-temporal-extent">Root Temporal
 Extent</loc>.  However if
 the <loc href="#terms-document-processing-context">document processing
 context</loc> specifies a range of applicable media times, those may modify

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -25630,7 +25630,7 @@ in the absence of any external constraints,
 is also the <loc href="#terms-root-temporal-extent">Root Temporal
 Extent</loc>.  However if
 the <loc href="#terms-document-processing-context">document processing
-context</loc> specifies a range of applicable media times, those modify
+context</loc> specifies a range of applicable media times, those may modify
 the resolved begin and end times and therefore
 the <loc href="#terms-root-temporal-extent">Root Temporal
 Extent</loc>.</p>

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -18002,11 +18002,27 @@ otherwise, if not invoked at this time, then resolve the implicit duration for e
 implicit duration resolved had this procedure been invoked;</p>
 </item>
 <item>
-<p>divide the active time duration of the current <loc href="#terms-document-instance">document instance</loc> into an ordered sequence
+<p>divide the active time duration, i.e. the <loc href="#terms-root-temporal-extent">root temporal extent,</loc>
+of the current <loc href="#terms-document-instance">document instance</loc> into an ordered sequence
 of time coordinates <code>{T<sub>0</sub>, T<sub>1</sub>, T<sub>2</sub>, ...}</code> where, at each time coordinate <code>T<sub>i</sub></code>,
 some element becomes temporally active or inactive.</p>
 </item>
 </olist>
+<note role="elaboration">
+<p>The result of this procedure is a set of time coordinates: the first may be greater than zero
+and the last may be a finite value.</p>
+<p>However there may be a benefit to some applications if they require that
+the first time coordinate is zero,
+or that the last time coordinate is infinite,
+or both, in other words, if they extend the root temporal extent.</p>
+<p>Similarly, the <loc href="#terms-document-processing-context">document processing context</loc>
+may constrain the range of time coordinates to fit within a defined range,
+for example by clamping time coordinates outside that range to the value of the range,
+and removing any resulting duplicates.</p>
+<p>This specification requires that the last time coordinate is infinite only when
+there is no end to the document's active duration and
+there is no document processing context constraint that prevents it.</p>
+</note>
 </def>
 </gitem>
 <gitem id="procedure-construct-anonymous-spans">

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -1904,7 +1904,8 @@ content rectangles are coterminous.</p>
 <gitem id="terms-root-temporal-extent">
 <label>[root temporal extent]</label>
 <def>
-<p>The temporal extent (interval) defined by the temporal beginning and ending of a <loc href="#terms-document-instance">document instance</loc>
+<p>The temporal extent (interval) defined by the temporal beginning and ending of a <loc href="#terms-document-instance">document instance</loc>,
+i.e., the time interval over which a <loc href="#terms-document-instance">document instance</loc> is active,
 in relationship with some external application or presentation context.</p>
 </def>
 </gitem>
@@ -6125,7 +6126,7 @@ zero or one <el>body</el> element.</p>
 </tr>
 </tbody>
 </table>
-<p>The <loc href="#terms-root-temporal-extent">root temporal extent</loc>, i.e., the time interval over which a <loc href="#terms-document-instance">document instance</loc> is active, has an implicit duration that is equal to the
+<p>The <loc href="#terms-root-temporal-extent">root temporal extent</loc> has an implicit duration that is equal to the
 implicit duration of the <el>body</el> element of the document, if the <el>body</el> element is present, or zero, if the <el>body</el> element is absent.</p>
 <p>If the <loc href="#style-attribute-extent"><att>tts:extent</att></loc> attribute is specified on the <el>tt</el>
 element, then it must adhere to <specref ref="style-attribute-extent"/>, in which case it
@@ -18002,27 +18003,12 @@ otherwise, if not invoked at this time, then resolve the implicit duration for e
 implicit duration resolved had this procedure been invoked;</p>
 </item>
 <item>
-<p>divide the active time duration, i.e. the <loc href="#terms-root-temporal-extent">root temporal extent,</loc>
-of the current <loc href="#terms-document-instance">document instance</loc> into an ordered sequence
+<p>divide the <loc href="#terms-root-temporal-extent">root temporal extent</loc>
+into an ordered sequence
 of time coordinates <code>{T<sub>0</sub>, T<sub>1</sub>, T<sub>2</sub>, ...}</code> where, at each time coordinate <code>T<sub>i</sub></code>,
 some element becomes temporally active or inactive.</p>
 </item>
 </olist>
-<note role="elaboration">
-<p>The result of this procedure is a set of time coordinates: the first may be greater than zero
-and the last may be a finite value.</p>
-<p>However there may be a benefit to some applications if they require that
-the first time coordinate is zero,
-or that the last time coordinate is infinite,
-or both, in other words, if they extend the root temporal extent.</p>
-<p>Similarly, the <loc href="#terms-document-processing-context">document processing context</loc>
-may constrain the range of time coordinates to fit within a defined range,
-for example by clamping time coordinates outside that range to the value of the range,
-and removing any resulting duplicates.</p>
-<p>This specification requires that the last time coordinate is infinite only when
-there is no end to the document's active duration and
-there is no document processing context constraint that prevents it.</p>
-</note>
 </def>
 </gitem>
 <gitem id="procedure-construct-anonymous-spans">
@@ -25639,11 +25625,12 @@ times in the absence of other external information.</caption>
 </table>
 <p>In this example, using the terminology of
 <bibref ref="smil3"/>, the implicit duration of the <el>body</el>
-element is identical to its computed duration which is also
-the <loc href="#terms-root-temporal-extent">Root Temporal
+element is identical to its computed duration which,
+in the absence of any external constraints, 
+is also the <loc href="#terms-root-temporal-extent">Root Temporal
 Extent</loc>.  However if
 the <loc href="#terms-document-processing-context">document processing
-context</loc> specifies a range of applicable media times, those limit
+context</loc> specifies a range of applicable media times, those modify
 the resolved begin and end times and therefore
 the <loc href="#terms-root-temporal-extent">Root Temporal
 Extent</loc>.</p>


### PR DESCRIPTION
Fix #1232 by clarifying that the active time duration of the current document instance _is_ the root temporal extent, and adding an elaboration note about the permitted range of ISD time coordinates.

___

This change can be previewed at https://rawgit.com/w3c/ttml2/issue-1232-clarify-isd-construction-build/index.html#procedure-resolve-timing