### PR TITLE
Metadata attributes apply as well as elements

### DIFF
--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -6170,10 +6170,10 @@ followed by zero or one <loc href="#styling-vocabulary-styling"><el>styling</el>
 followed by zero or one <loc href="#layout-vocabulary-layout"><el>layout</el></loc> element,
 followed by zero or one <loc href="#animation-vocabulary-animation"><el>animation</el></loc> element.</p>
 <p>Any metadata specified by children in the <loc href="#element-vocab-group-metadata"><code>Metadata.class</code></loc>
-element group applies semantically to the <loc href="#terms-document-instance">document instance</loc> as a
+element group apply semantically to the <loc href="#terms-document-instance">document instance</loc> as a
 whole, and not just the <el>head</el> element.</p>
 <p>Any parameters specified by children in the <code>Parameters.class</code>
-element group applies semantically to the <loc href="#terms-document-instance">document instance</loc> as a
+element group apply semantically to the <loc href="#terms-document-instance">document instance</loc> as a
 whole, and not just the <el>head</el> element.</p>
 <p>A <el>resources</el> child element is used to specify embedded content constructs
 that are referenced from certain style constructs and
@@ -6219,7 +6219,8 @@ followed by zero or more
 elements in the <loc href="#element-vocab-group-animation"><code>Animation.class</code></loc> element group,
 followed by zero or more <el>div</el> or <loc href="#element-vocab-group-embedded"><code>Embedded.class</code></loc> element group elements.</p>
 <p>Any metadata specified by children in the <loc href="#element-vocab-group-metadata"><code>Metadata.class</code></loc>
-element group applies semantically to the <el>body</el> element and its descendants as a whole.</p>
+element group or by <loc href="#attribute-vocab-group-metadata">Metadata attributes</loc>
+apply semantically to the <el>body</el> element and its descendants as a whole.</p>
 <p>Any animation elements specified by children in the <loc href="#element-vocab-group-animation"><code>Animation.class</code></loc>
 element group apply semantically to the <el>body</el> element.</p>
 <table id="elt-syntax-body" role="syntax">
@@ -6313,7 +6314,8 @@ element in the <loc href="#element-vocab-group-layout"><code>Layout.class</code>
 followed by zero or more elements in the <loc href="#element-vocab-group-block"><code>Block.class</code></loc> or
 <loc href="#element-vocab-group-embedded"><code>Embedded.class</code></loc> element groups.</p>
 <p>Any metadata specified by children in the <loc href="#element-vocab-group-metadata"><code>Metadata.class</code></loc>
-element group applies semantically to the <el>div</el> element and its descendants as a whole.</p>
+element group or by <loc href="#attribute-vocab-group-metadata">Metadata attributes</loc>
+apply semantically to the <el>div</el> element and its descendants as a whole.</p>
 <p>Any animation elements specified by children in the <loc href="#element-vocab-group-animation"><code>Animation.class</code></loc>
 element group apply semantically to the <el>div</el> element.</p>
 <table id="elt-syntax-div" role="syntax">
@@ -6373,7 +6375,8 @@ element in the <loc href="#element-vocab-group-layout"><code>Layout.class</code>
 followed by zero or more elements in the <loc href="#element-vocab-group-inline"><code>Inline.class</code></loc> or
 <loc href="#element-vocab-group-embedded"><code>Embedded.class</code></loc> element groups.</p>
 <p>Any metadata specified by children in the <loc href="#element-vocab-group-metadata"><code>Metadata.class</code></loc>
-element group applies semantically to the <el>p</el> element and its descendants as a whole.</p>
+element group or by <loc href="#attribute-vocab-group-metadata">Metadata attributes</loc>
+apply semantically to the <el>p</el> element and its descendants as a whole.</p>
 <p>Any animation elements specified by children in the <loc href="#element-vocab-group-animation"><code>Animation.class</code></loc>
 element group apply semantically to the <el>p</el> element.</p>
 <table id="elt-syntax-p" role="syntax">
@@ -6444,7 +6447,8 @@ elements in the <loc href="#element-vocab-group-animation"><code>Animation.class
 followed by zero or more elements in the <loc href="#element-vocab-group-inline"><code>Inline.class</code></loc> or
 <loc href="#element-vocab-group-embedded"><code>Embedded.class</code></loc> element groups.</p>
 <p>Any metadata specified by children in the <loc href="#element-vocab-group-metadata"><code>Metadata.class</code></loc>
-element group applies semantically to the <el>span</el> element and its descendants as a whole.</p>
+element group or by <loc href="#attribute-vocab-group-metadata">Metadata attributes</loc>
+apply semantically to the <el>span</el> element and its descendants as a whole.</p>
 <p>Any animation elements specified by children in the <loc href="#element-vocab-group-animation"><code>Animation.class</code></loc>
 element group apply semantically to the <el>span</el> element.</p>
 <table id="elt-syntax-span" role="syntax">
@@ -6515,7 +6519,8 @@ is subject to <phrase role="strong"><loc href="#procedure-construct-anonymous-sp
 <head>br</head>
 <p>The <el>br</el> element denotes an explicit line break.</p>
 <p>Any metadata specified by children in the <loc href="#element-vocab-group-metadata"><code>Metadata.class</code></loc>
-element group applies semantically to the <el>br</el> element and its descendants as a whole.</p>
+element group or by <loc href="#attribute-vocab-group-metadata">Metadata attributes</loc>
+apply semantically to the <el>br</el> element and its descendants as a whole.</p>
 <p><phrase role="deprecated">The use of <code>Animation.class</code> children is deprecated.</phrase></p>
 <note role="explanation">
 <p>No style attributes apply to <el>br</el> elements therefore animation has no effect on <el>br</el>.</p>
@@ -17558,7 +17563,7 @@ elements in the <loc href="#element-vocab-group-animation"><code>Animation.class
 followed by
 zero or more <el>style</el> elements.</p>
 <p>Any metadata specified by children in the <loc href="#element-vocab-group-metadata"><code>Metadata.class</code></loc>
-element group applies semantically to the <el>region</el> element and its descendants as a whole.
+element group apply semantically to the <el>region</el> element and its descendants as a whole.
 Any animation elements specified by children in the <loc href="#element-vocab-group-animation"><code>Animation.class</code></loc>
 element group apply semantically to the <el>region</el> element.
 Any <el>style</el> child element must be considered a local style

--- a/spec/ttml2.xml
+++ b/spec/ttml2.xml
@@ -6218,8 +6218,8 @@ elements in the <loc href="#element-vocab-group-metadata"><code>Metadata.class</
 followed by zero or more
 elements in the <loc href="#element-vocab-group-animation"><code>Animation.class</code></loc> element group,
 followed by zero or more <el>div</el> or <loc href="#element-vocab-group-embedded"><code>Embedded.class</code></loc> element group elements.</p>
-<p>Any metadata specified by children in the <loc href="#element-vocab-group-metadata"><code>Metadata.class</code></loc>
-element group or by <loc href="#attribute-vocab-group-metadata">Metadata attributes</loc>
+<p>Any metadata specified by <loc href="#attribute-vocab-group-metadata">Metadata attributes</loc>
+or by children in the <loc href="#element-vocab-group-metadata"><code>Metadata.class</code></loc> element group 
 apply semantically to the <el>body</el> element and its descendants as a whole.</p>
 <p>Any animation elements specified by children in the <loc href="#element-vocab-group-animation"><code>Animation.class</code></loc>
 element group apply semantically to the <el>body</el> element.</p>
@@ -6313,8 +6313,8 @@ followed by zero or one
 element in the <loc href="#element-vocab-group-layout"><code>Layout.class</code></loc> element group,
 followed by zero or more elements in the <loc href="#element-vocab-group-block"><code>Block.class</code></loc> or
 <loc href="#element-vocab-group-embedded"><code>Embedded.class</code></loc> element groups.</p>
-<p>Any metadata specified by children in the <loc href="#element-vocab-group-metadata"><code>Metadata.class</code></loc>
-element group or by <loc href="#attribute-vocab-group-metadata">Metadata attributes</loc>
+<p>Any metadata specified by <loc href="#attribute-vocab-group-metadata">Metadata attributes</loc>
+or by children in the <loc href="#element-vocab-group-metadata"><code>Metadata.class</code></loc> element group
 apply semantically to the <el>div</el> element and its descendants as a whole.</p>
 <p>Any animation elements specified by children in the <loc href="#element-vocab-group-animation"><code>Animation.class</code></loc>
 element group apply semantically to the <el>div</el> element.</p>
@@ -6374,8 +6374,8 @@ followed by zero or one
 element in the <loc href="#element-vocab-group-layout"><code>Layout.class</code></loc> element group,
 followed by zero or more elements in the <loc href="#element-vocab-group-inline"><code>Inline.class</code></loc> or
 <loc href="#element-vocab-group-embedded"><code>Embedded.class</code></loc> element groups.</p>
-<p>Any metadata specified by children in the <loc href="#element-vocab-group-metadata"><code>Metadata.class</code></loc>
-element group or by <loc href="#attribute-vocab-group-metadata">Metadata attributes</loc>
+<p>Any metadata specified by <loc href="#attribute-vocab-group-metadata">Metadata attributes</loc>
+or by children in the <loc href="#element-vocab-group-metadata"><code>Metadata.class</code></loc> element group
 apply semantically to the <el>p</el> element and its descendants as a whole.</p>
 <p>Any animation elements specified by children in the <loc href="#element-vocab-group-animation"><code>Animation.class</code></loc>
 element group apply semantically to the <el>p</el> element.</p>
@@ -6446,8 +6446,8 @@ followed by zero or more
 elements in the <loc href="#element-vocab-group-animation"><code>Animation.class</code></loc> element group,
 followed by zero or more elements in the <loc href="#element-vocab-group-inline"><code>Inline.class</code></loc> or
 <loc href="#element-vocab-group-embedded"><code>Embedded.class</code></loc> element groups.</p>
-<p>Any metadata specified by children in the <loc href="#element-vocab-group-metadata"><code>Metadata.class</code></loc>
-element group or by <loc href="#attribute-vocab-group-metadata">Metadata attributes</loc>
+<p>Any metadata specified by <loc href="#attribute-vocab-group-metadata">Metadata attributes</loc>
+or by children in the <loc href="#element-vocab-group-metadata"><code>Metadata.class</code></loc> element group
 apply semantically to the <el>span</el> element and its descendants as a whole.</p>
 <p>Any animation elements specified by children in the <loc href="#element-vocab-group-animation"><code>Animation.class</code></loc>
 element group apply semantically to the <el>span</el> element.</p>
@@ -6518,8 +6518,8 @@ is subject to <phrase role="strong"><loc href="#procedure-construct-anonymous-sp
 <div3 id="content-vocabulary-br">
 <head>br</head>
 <p>The <el>br</el> element denotes an explicit line break.</p>
-<p>Any metadata specified by children in the <loc href="#element-vocab-group-metadata"><code>Metadata.class</code></loc>
-element group or by <loc href="#attribute-vocab-group-metadata">Metadata attributes</loc>
+<p>Any metadata specified by <loc href="#attribute-vocab-group-metadata">Metadata attributes</loc>
+or by children in the <loc href="#element-vocab-group-metadata"><code>Metadata.class</code></loc> element group
 apply semantically to the <el>br</el> element and its descendants as a whole.</p>
 <p><phrase role="deprecated">The use of <code>Animation.class</code> children is deprecated.</phrase></p>
 <note role="explanation">


### PR DESCRIPTION
Closes #1271 by specifying that metadata attributes apply semantically as well as metadata elements, on those elements that accept metadata attributes.

In passing, also made a grammar fix where plurals "Any metadata" and "Any parameters" had singular "applies" form of the verb - replaced with plural "apply".